### PR TITLE
Demo: Xvnc + Selenium

### DIFF
--- a/demo/JENKINS_HOME/jobs/docker-workflow/config.xml
+++ b/demo/JENKINS_HOME/jobs/docker-workflow/config.xml
@@ -1,19 +1,19 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<flow-definition>
+<flow-definition plugin="workflow-job@1.8">
   <actions/>
-  <description>Demonstrates Jenkins Workflow integration with Docker based on CloudBees Docker Workflow Plugin.
+  <description>Demonstrates Jenkins Workflow integration with Docker based on CloudBees Docker Workflow Plugin.&#xd;
   </description>
   <keepDependencies>false</keepDependencies>
   <properties/>
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@1.8">
     <script>node {
-def maven32 = docker.image(&apos;maven:3.2-jdk-7-onbuild&apos;); // https://registry.hub.docker.com/_/maven/;
+def maven = docker.image(&apos;maven:3.3.3-jdk-8&apos;); // https://registry.hub.docker.com/_/maven/
 
 stage &apos;Mirror&apos;
 // First make sure the slave has this image.
 // (If you could set your registry below to mirror Docker Hub,
-// this would be unnecessary as maven32.inside would pull the image.)
-maven32.pull()
+// this would be unnecessary as maven.inside would pull the image.)
+maven.pull()
 // We are pushing to a private secure docker registry in this demo.
 // &apos;docker-registry-login&apos; is the username/password credentials ID as defined in Jenkins Credentials.
 // This is used to authenticate the docker client to the registry.
@@ -23,7 +23,9 @@ docker.withRegistry(&apos;https://docker.example.com/&apos;, &apos;docker-regist
 
     // spin up a Maven container to build the petclinic app from source
     // (we are only using -v here to share the Maven local repository across demo runs; otherwise would set localRepository=${pwd}/m2repo)
-    maven32.inside(&apos;-v /m2repo:/m2repo&apos;) {
+    def pcImg
+    dir(&apos;app&apos;) {
+    maven.inside(&apos;-v /m2repo:/m2repo&apos;) {
         // Check out the source code.
         git &apos;https://github.com/tfennelly/spring-petclinic.git&apos;
 
@@ -36,12 +38,13 @@ docker.withRegistry(&apos;https://docker.example.com/&apos;, &apos;docker-regist
     }
     
     stage &apos;Bake Docker image&apos;
-    // use the spring-petclinic Dockerfile (see above &apos;maven32.inside()&apos; block)
+    // use the spring-petclinic Dockerfile (see above &apos;maven.inside()&apos; block)
     // to build container that can run the app. The Dockerfile is in the cwd of the active workspace
-    // (see above maven32.inside() block), so we pass &apos;.&apos; as the build PATH param. The Dockerfile
+    // (see above maven.inside() block), so we pass &apos;.&apos; as the build PATH param. The Dockerfile
     // (see https://github.com/tfennelly/spring-petclinic/blob/master/Dockerfile) expects the petclinic.war
     // file to be in the &apos;target&apos; dir of the workspace, which will be the case.
-    def pcImg = docker.build(&quot;examplecorp/spring-petclinic:${env.BUILD_TAG}&quot;, &apos;.&apos;)
+      pcImg = docker.build(&quot;examplecorp/spring-petclinic:${env.BUILD_TAG}&quot;, &apos;.&apos;)
+    }
 
     // Let&apos;s tag and push the newly built image. Will tag using the image name provided
     // in the &apos;docker.build&apos; call above (which included the build number on the tag).
@@ -50,13 +53,17 @@ docker.withRegistry(&apos;https://docker.example.com/&apos;, &apos;docker-regist
     stage &apos;Test Image&apos;
     // Run the petclinic app in its own docker container
     pcImg.withRun {petclinic -&gt;
-        // Spin up a maven test container, linking it to the petclinic app container allowing
-        // the maven tests to fire HTTP requests between the containers.
-        maven32.inside(&quot;-v /m2repo:/m2repo --link=${petclinic.id}:petclinic&quot;) {
-            git &apos;https://github.com/tfennelly/spring-petclinic-tests.git&apos;
+        dir(&apos;test&apos;) {
+        git url: &apos;https://github.com/jglick/spring-petclinic-tests.git&apos;, branch: &apos;selenium&apos;
 
+        // Spin up a maven + xvnc test container, linking it to the petclinic app container allowing
+        // the maven tests to fire HTTP requests between the containers.
+        docker.build(&apos;examplecorp/spring-petclinic-tests:snapshot&apos;).inside(&quot;-v /m2repo:/m2repo --link=${petclinic.id}:petclinic&quot;) {
             writeFile file: &apos;settings.xml&apos;, text: &apos;&lt;settings&gt;&lt;localRepository&gt;/m2repo&lt;/localRepository&gt;&lt;/settings&gt;&apos;
-            sh &apos;mvn -B -s settings.xml clean package&apos;
+            wrap([$class: &apos;Xvnc&apos;, takeScreenshot: false, useXauthority: true]) {
+              sh &apos;mvn -B -s settings.xml clean package&apos;
+            }
+        }
         }
     }
 

--- a/demo/plugins.txt
+++ b/demo/plugins.txt
@@ -2,3 +2,4 @@ docker-workflow:@VERSION@
 docker-commons:1.0
 authentication-tokens:1.1
 credentials:1.22
+xvnc:1.22


### PR DESCRIPTION
Shows how you can build out a test environment running Firefox inside a container, and taking advantage of Workflow 1.8 build wrappers.

Subsumes #9. @reviewbybees esp. @tfennelly