### PR TITLE
[FIXED JENKINS-28611] Execute docker with the node environment

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -169,7 +169,6 @@ public class WithContainerStep extends AbstractStepImpl {
                     List<String> prefix = new ArrayList<String>(Arrays.asList("docker", "exec", container, "env"));
                     Set<String> envReduced = new TreeSet<String>(Arrays.asList(starter.envs()));
                     envReduced.removeAll(Arrays.asList(envHost));
-                    starter.envs(new String[0]);
                     prefix.addAll(envReduced);
                     // Adapted from decorateByPrefix:
                     starter.cmds().addAll(0, prefix);

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -84,13 +84,14 @@ public class WithContainerStepTest {
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +
                     "  withDockerContainer('httpd:2.4.12') {\n" +
-                    "    sh 'echo sleeping now with JENKINS_SERVER_COOKIE=$JENKINS_SERVER_COOKIE; sleep 999'\n" +
+                    "    sh 'trap \\'echo got SIGTERM\\' TERM; trap \\'echo exiting; exit 99\\' EXIT; echo sleeping now with JENKINS_SERVER_COOKIE=$JENKINS_SERVER_COOKIE; sleep 999'\n" +
                     "  }\n" +
                     "}", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 JenkinsRuleExt.waitForMessage("sleeping now", b);
                 b.doStop();
                 story.j.assertBuildStatus(Result.ABORTED, JenkinsRuleExt.waitForCompletion(b));
+                story.j.assertLogContains("script returned exit code 99", b);
             }
         });
     }


### PR DESCRIPTION
Allows to take into account envvars defined at node level (such as DOCKER_HOST) to execute
docker.

@reviewbybees