### PR TITLE
Trying to fix DockerDSLTest#build

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -238,6 +238,8 @@ public class DockerDSLTest {
                     "  writeFile file: 'stuff2', text: 'world'\n" +
                     "  writeFile file: 'stuff3', text: env.BUILD_NUMBER\n" +
                     "  sh 'touch -t 201501010000 stuff*'\n" + // image hash includes timestamps!
+                    "  def helloworld = docker.image('hello-world');\n" +
+                    "  helloworld.pull();\n" +
                     "  writeFile file: 'Dockerfile', text: '# This is a test.\\n\\nFROM hello-world@" + ancestorImageId + "\\nCOPY stuff1 /\\nCOPY stuff2 /\\nCOPY stuff3 /\\n'\n" +
                     "  def built = docker.build 'hello-world-stuff'\n" +
                     "  echo \"built ${built.id}\"\n" +

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -245,7 +245,7 @@ public class DockerDSLTest {
                     "  echo \"built ${built.id}\"\n" +
                     "}", true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                String descendantImageId1 = "c04cd8a9a37440562c655c8076dc47a41ae7855096e73c6e8aa5f01f2ed52b85";
+                String descendantImageId1 = "8402e89d5ff08ab6886fb4b274e06974a6d0dc9a2907646d15f6cde800aefab6";
                 story.j.assertLogContains("built hello-world-stuff", b);
                 story.j.assertLogContains(descendantImageId1.substring(0, 12), b);
                 Fingerprint f = DockerFingerprints.of(ancestorImageId);
@@ -263,7 +263,7 @@ public class DockerDSLTest {
                 assertEquals(Collections.singleton(ancestorImageId), ancestorFacet.getAncestorImageIds());
                 assertEquals(descendantImageId1, ancestorFacet.getImageId());
                 b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                String descendantImageId2 = "0703ebc9f6a713f56191ce4db96338f4572de53479bc32efd60717f789d91089";
+                String descendantImageId2 = "ef0c82b72d4ca8968c3d092cb94994dc45e86295fce8ec2e7c6fb4505cede274";
                 story.j.assertLogContains("built hello-world-stuff", b);
                 story.j.assertLogContains(descendantImageId2.substring(0, 12), b);
                 f = DockerFingerprints.of(ancestorImageId);

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -245,7 +245,7 @@ public class DockerDSLTest {
                     "  echo \"built ${built.id}\"\n" +
                     "}", true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                String descendantImageId1 = "8402e89d5ff08ab6886fb4b274e06974a6d0dc9a2907646d15f6cde800aefab6";
+                String descendantImageId1 = "c04cd8a9a37440562c655c8076dc47a41ae7855096e73c6e8aa5f01f2ed52b85";
                 story.j.assertLogContains("built hello-world-stuff", b);
                 story.j.assertLogContains(descendantImageId1.substring(0, 12), b);
                 Fingerprint f = DockerFingerprints.of(ancestorImageId);
@@ -263,7 +263,7 @@ public class DockerDSLTest {
                 assertEquals(Collections.singleton(ancestorImageId), ancestorFacet.getAncestorImageIds());
                 assertEquals(descendantImageId1, ancestorFacet.getImageId());
                 b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                String descendantImageId2 = "ef0c82b72d4ca8968c3d092cb94994dc45e86295fce8ec2e7c6fb4505cede274";
+                String descendantImageId2 = "0703ebc9f6a713f56191ce4db96338f4572de53479bc32efd60717f789d91089";
                 story.j.assertLogContains("built hello-world-stuff", b);
                 story.j.assertLogContains(descendantImageId2.substring(0, 12), b);
                 f = DockerFingerprints.of(ancestorImageId);


### PR DESCRIPTION
This test wrongly assumes hello-world image is already in cache.

This change itself is not enough to fix the test for me : i'm getting different ids when executing the test (8402e89d5ff08ab6886fb4b274e06974a6d0dc9a2907646d15f6cde800aefab6 then ef0c82b72d4ca8968c3d092cb94994dc45e86295fce8ec2e7c6fb4505cede274) with the following docker version. Maybe docker hash function has changed? I don't know.

````
Client version: 1.7.0
Client API version: 1.19
Go version (client): go1.4.2
Git commit (client): 0baf609
OS/Arch (client): darwin/amd64
Server version: 1.7.0
Server API version: 1.19
Go version (server): go1.4.2
Git commit (server): 0baf609
OS/Arch (server): linux/amd64
````

@jglick mostly.