### PR TITLE
docker.build with a custom Dockerfile

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -72,10 +72,10 @@ class Docker implements Serializable {
         new Image(this, id)
     }
 
-    public Image build(String image, String dir = '.') {
+    public Image build(String image, String dir = '.', String dockerFile = 'Dockerfile') {
         node {
-            script.sh "docker build -t ${image} ${dir}"
-            script.dockerFingerprintFrom dockerfile: "${dir}/Dockerfile", image: image, toolName: script.env.DOCKER_TOOL_NAME
+            script.sh "docker build -t ${image} -f ${dockerFile} ${dir}"
+            script.dockerFingerprintFrom dockerfile: "${dir}/${dockerFile}", image: image, toolName: script.env.DOCKER_TOOL_NAME
             this.image(image)
         }
     }

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
@@ -41,10 +41,10 @@
                 Creates an <code>Image</code> object with a specified name or ID. See below.
             </p>
         </dd>
-        <dt><code>build(image[, dir])</code></dt>
+        <dt><code>build(image[, dir, dockerFile])</code></dt>
         <dd>
             <p>
-                Runs <code>docker build</code> to create and tag the specified image from a <code>Dockerfile</code> in the current directory (or <code>dir</code>).
+                Runs <code>docker build</code> to create and tag the specified image from a <code>Dockerfile</code> (or <code>dockerFile</code>) in the current directory (or <code>dir</code>).
                 Returns the resulting <code>Image</code> object.
                 Records a <code>FROM</code> fingerprint in the build.
             </p>


### PR DESCRIPTION
Added the option to specify Dockerfile when building a container. Example:

```groovy
docker.build("jenkins-test", ".", "Dockerfile.test")
```