### PR TITLE
[JENKINS-33063] Allow Image.run() to provide arguments to the container’s command

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -123,7 +123,7 @@ class Docker implements Serializable {
 
         public Container run(String args = '', String command = "") {
             docker.node {
-                docker.script.sh "docker run -d${args != '' ? ' ' + args : ''} ${id} ${command} > .container"
+                docker.script.sh "docker run -d${args != '' ? ' ' + args : ''} ${id}${command != '' ? ' ' + command : ''} > .container"
                 def container = docker.script.readFile('.container').trim()
                 docker.script.dockerFingerprintRun containerId: container, toolName: docker.script.env.DOCKER_TOOL_NAME
                 new Container(docker, container)

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -72,10 +72,10 @@ class Docker implements Serializable {
         new Image(this, id)
     }
 
-    public Image build(String image, String dir = '.') {
+    public Image build(String image, String dir = '.', String dockerFile = 'Dockerfile') {
         node {
-            script.sh "docker build -t ${image} ${dir}"
-            script.dockerFingerprintFrom dockerfile: "${dir}/Dockerfile", image: image, toolName: script.env.DOCKER_TOOL_NAME
+            script.sh "docker build -t ${image} -f ${dockerFile} ${dir}"
+            script.dockerFingerprintFrom dockerfile: "${dir}/${dockerFile}", image: image, toolName: script.env.DOCKER_TOOL_NAME
             this.image(image)
         }
     }

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -72,10 +72,10 @@ class Docker implements Serializable {
         new Image(this, id)
     }
 
-    public Image build(String image, String dir = '.', String dockerFile = 'Dockerfile') {
+    public Image build(String image, String dir = '.') {
         node {
-            script.sh "docker build -t ${image} -f ${dockerFile} ${dir}"
-            script.dockerFingerprintFrom dockerfile: "${dir}/${dockerFile}", image: image, toolName: script.env.DOCKER_TOOL_NAME
+            script.sh "docker build -t ${image} ${dir}"
+            script.dockerFingerprintFrom dockerfile: "${dir}/Dockerfile", image: image, toolName: script.env.DOCKER_TOOL_NAME
             this.image(image)
         }
     }

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -121,9 +121,9 @@ class Docker implements Serializable {
             }
         }
 
-        public Container run(String args = '') {
+        public Container run(String args = '', String command = "") {
             docker.node {
-                docker.script.sh "docker run -d${args != '' ? ' ' + args : ''} ${id} > .container"
+                docker.script.sh "docker run -d${args != '' ? ' ' + args : ''} ${id} ${command} > .container"
                 def container = docker.script.readFile('.container').trim()
                 docker.script.dockerFingerprintRun containerId: container, toolName: docker.script.env.DOCKER_TOOL_NAME
                 new Container(docker, container)

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
@@ -55,11 +55,12 @@
                 The image name with optional tag (<code>mycorp/myapp</code>, <code>mycorp/myapp:latest</code>) or ID (hexadecimal hash).
             </p>
         </dd>
-        <dt><code>Image.run([args])</code></dt>
+        <dt><code>Image.run([args, command])</code></dt>
         <dd>
             <p>
                 Uses <code>docker run</code> to run the image, and returns a <code>Container</code> which you could <code>stop</code> later.
                 Additional <code>args</code> may be added, such as <code>'-p 8080:8080 --memory-swap=-1'</code>.
+                Optional <code>command</code> is equivalent to Docker command specified after the image.
                 Records a run fingerprint in the build.
             </p>
         </dd>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
@@ -41,10 +41,10 @@
                 Creates an <code>Image</code> object with a specified name or ID. See below.
             </p>
         </dd>
-        <dt><code>build(image[, dir])</code></dt>
+        <dt><code>build(image[, dir, dockerFile])</code></dt>
         <dd>
             <p>
-                Runs <code>docker build</code> to create and tag the specified image from a <code>Dockerfile</code> in the current directory (or <code>dir</code>).
+                Runs <code>docker build</code> to create and tag the specified image from a <code>Dockerfile</code> (or <code>dockerFile</code>) in the current directory (or <code>dir</code>).
                 Returns the resulting <code>Image</code> object.
                 Records a <code>FROM</code> fingerprint in the build.
             </p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
@@ -41,10 +41,10 @@
                 Creates an <code>Image</code> object with a specified name or ID. See below.
             </p>
         </dd>
-        <dt><code>build(image[, dir, dockerFile])</code></dt>
+        <dt><code>build(image[, dir])</code></dt>
         <dd>
             <p>
-                Runs <code>docker build</code> to create and tag the specified image from a <code>Dockerfile</code> (or <code>dockerFile</code>) in the current directory (or <code>dir</code>).
+                Runs <code>docker build</code> to create and tag the specified image from a <code>Dockerfile</code> in the current directory (or <code>dir</code>).
                 Returns the resulting <code>Image</code> object.
                 Records a <code>FROM</code> fingerprint in the build.
             </p>

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -324,4 +324,20 @@ public class DockerDSLTest {
             }
         });
     }
+
+    @Test public void run() {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                assumeDocker();
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
+                p.setDefinition(new CpsFlowDefinition(
+                        "node {\n" +
+                                "     def busybox = docker.image('busybox');\n" +
+                                "     busybox.run('--rm', 'echo \"Hello\"');\n" +
+                                "}", true));
+                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                story.j.assertLogContains("Hello", b);
+            }
+        });
+    }
 }


### PR DESCRIPTION
[JENKINS-33063](https://issues.jenkins-ci.org/browse/JENKINS-33063)