### PR TITLE
Bump parent pom version to 2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.3</version>
+        <version>2.9</version>
     </parent>
     <artifactId>docker-workflow</artifactId>
     <version>1.5-SNAPSHOT</version>


### PR DESCRIPTION
To fix PCT against 2.x baselines. Newer version of Jenkins Test Harness fixes the build.

@reviewbybees 