### PR TITLE
Fixing test

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -333,7 +333,7 @@ public class DockerDSLTest {
                 p.setDefinition(new CpsFlowDefinition(
                         "node {\n" +
                                 "     def busybox = docker.image('busybox');\n" +
-                                "     busybox.run('--rm', 'echo \"Hello\"');\n" +
+                                "     busybox.run('--tty', 'echo \"Hello\"').stop();\n" +
                                 "}", true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
                 story.j.assertLogContains("Hello", b);


### PR DESCRIPTION
The test from #37 was broken, at least when using Docker 1.11.1:

```
+ docker run -d --rm busybox echo Hello
Conflicting options: --rm and -d
```

Also the test neglected to call `Container.stop`, so it was creating a zombie container on every run.

@reviewbybees esp. @vfarcic