### PR TITLE
[JENKINS-31225] Rely on $NODE_NAME, not $HOME, to see if we are inside `node {}` or not

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -58,7 +58,7 @@ class Docker implements Serializable {
     }
 
     private <V> V node(Closure<V> body) {
-        if (script.env.HOME != null) { // http://unix.stackexchange.com/a/123859/26736
+        if (script.env.NODE_NAME != null) {
             // Already inside a node block.
             body()
         } else {


### PR DESCRIPTION
[JENKINS-31225](https://issues.jenkins-ci.org/browse/JENKINS-31225)

Possible due to baseline update in #49.

@reviewbybees esp. @jtnord