### PR TITLE
Improve detection of containerized Jenkins instance

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -62,6 +62,14 @@ public class DockerClient {
 
     // e.g. 2015-04-09T13:40:21.981801679Z
     public static final String DOCKER_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+    
+    /**
+     * Known cgroup formats
+     * 
+     * 4:cpuset:/system.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope
+     * 2:cpu:/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
+     */
+    public static final String CGROUP_MATCHER_PATTERN = "(?m)^\\d+:\\w+:(?:/[\\w\\.]+)?/docker[-/](?<containerId>\\p{XDigit}{12,})(?:\\.scope)?$";
 
     private Launcher launcher;
     private final @CheckForNull Node node;
@@ -289,7 +297,7 @@ public class DockerClient {
      * it isn't containerized.
      */
     public Optional<String> getContainerIdIfContainerized() throws IOException, InterruptedException {
-        final Pattern pattern = Pattern.compile("(?m)^\\d+:\\w+:/docker/(?<containerId>\\p{XDigit}{12,})$");
+        final Pattern pattern = Pattern.compile(CGROUP_MATCHER_PATTERN);
         if (node == null) {
             return Optional.absent();
         }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
@@ -33,9 +33,12 @@ import org.jenkinsci.plugins.docker.commons.fingerprint.ContainerRecord;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.jvnet.hudson.test.For;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
@@ -86,6 +89,23 @@ public class DockerClientTest {
     @Test
     public void test_invalid_version() {
         Assert.assertNull(DockerClient.parseVersionNumber("xxx"));
+    }
+    
+    @Test
+    public void test_cgroup_string_matching() {
+    	
+    	final String[] possibleCgroupStrings = new String[] {
+    		"2:cpu:/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
+    		"4:cpuset:/system.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope"
+    	};
+    	
+    	for (final String possibleCgroupString : possibleCgroupStrings) {
+    		final Pattern pattern = Pattern.compile(DockerClient.CGROUP_MATCHER_PATTERN);
+    		Matcher matcher = pattern.matcher(possibleCgroupString);
+    		Assert.assertTrue(matcher.find());
+    		Assert.assertEquals("3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b", matcher.group(1));
+		}
+    	
     }
     
     private EnvVars newLaunchEnv() {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
@@ -33,7 +33,6 @@ import org.jenkinsci.plugins.docker.commons.fingerprint.ContainerRecord;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.jvnet.hudson.test.For;
 
 import java.io.IOException;
 import java.util.Collections;


### PR DESCRIPTION
It seems there are multiple formats possible for the content of /proc/self/cgroup. I modified the regex to work with the one that I see in my environment. After the patch it works as expected.
Also added a test to make sure it works with both kown variations of the format.