### PR TITLE
[JENKINS-36332] Allow a command argument to be passed to Image.withRun

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -139,9 +139,9 @@ class Docker implements Serializable {
             }
         }
 
-        public <V> V withRun(String args = '', Closure<V> body) {
+        public <V> V withRun(String args = '', String command = "", Closure<V> body) {
             docker.node {
-                Container c = run(args)
+                Container c = run(args, command)
                 try {
                     body.call(c)
                 } finally {

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
@@ -65,7 +65,7 @@
                 Records a run fingerprint in the build.
             </p>
         </dd>
-        <dt><code>Image.withRun[(args)] {…}</code></dt>
+        <dt><code>Image.withRun([args, command]) {…}</code></dt>
         <dd>
             <p>
                 Like <code>run</code> but stops the container as soon as its body exits, so you do not need a <code>try</code>-<code>finally</code> block.

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
@@ -65,7 +65,7 @@
                 Records a run fingerprint in the build.
             </p>
         </dd>
-        <dt><code>Image.withRun([args, command]) {…}</code></dt>
+        <dt><code>Image.withRun[(args[, command])] {…}</code></dt>
         <dd>
             <p>
                 Like <code>run</code> but stops the container as soon as its body exits, so you do not need a <code>try</code>-<code>finally</code> block.

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -230,31 +230,16 @@ public class DockerDSLTest {
                 assumeDocker();
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
-                        "  semaphore 'wait'\n" +
                         " docker.image('maven:3.3.9-jdk-8').withRun(\"--entrypoint mvn\", \"-version\") {c ->\n" +
                                 "  sh \"docker logs ${c.id}\"" +
                                 "}", true));
-                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
-                SemaphoreStep.waitForStart("wait/1", b);
-            }
-        });
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                SemaphoreStep.success("wait/1", null);
-                WorkflowJob p = story.j.jenkins.getItemByFullName("prj", WorkflowJob.class);
-                WorkflowRun b = p.getLastBuild();
-                story.j.assertLogContains("Maven home: /usr/share/maven", story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b)));
-                story.j.assertLogContains("Java home: /usr/lib/jvm/java-8-openjdk-amd64/jre", b);
+                story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
                 DockerClient client = new DockerClient(new Launcher.LocalLauncher(StreamTaskListener.NULL), null, null);
-                String httpdIID = client.inspect(new EnvVars(), "maven:3.3.9-jdk-8", ".Id");
-                Fingerprint f = DockerFingerprints.of(httpdIID);
+                String mavenIID = client.inspect(new EnvVars(), "maven:3.3.9-jdk-8", ".Id");
+                Fingerprint f = DockerFingerprints.of(mavenIID);
                 assertNotNull(f);
                 DockerRunFingerprintFacet facet = f.getFacet(DockerRunFingerprintFacet.class);
                 assertNotNull(facet);
-                assertEquals(1, facet.records.size());
-                assertNotNull(facet.records.get(0).getContainerName());
-                assertEquals(Fingerprint.RangeSet.fromString("1", false), facet.getRangeSet(p));
-                assertEquals(Collections.singleton("maven"), DockerImageExtractor.getDockerImagesUsedByJobFromAll(p));
             }
         });
     }


### PR DESCRIPTION
[JENKINS-36332](https://issues.jenkins-ci.org/browse/JENKINS-36332)

I would like to apply the same command parameter that's used in  JENKINS-33063 to the "withRun" method so that I can clean up most of my containers as soon as they're finished.

Given that I also kind of need this I just PR my take on the solution :)