### PR TITLE
Fixing Image.inside according to make -C demo run-snapshot

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -114,7 +114,7 @@ class Docker implements Serializable {
         
         public <V> V inside(String args = '', Closure<V> body) {
             docker.node {
-                if (docker.script.sh(script: "docker inspect -f . ${id} >&- 2>&-", returnStatus: true) != 0) {
+                if (docker.script.sh(script: "docker inspect -f . ${id}", returnStatus: true) != 0) {
                     // Not yet present locally.
                     // withDockerContainer requires the image to be available locally, since its start phase is not a durable task.
                     pull()


### PR DESCRIPTION
#54 seems to have broken the demo, for reasons I do not exactly understand; anyway, `git-bisect` led me here, and making the script less quiet does work.

@reviewbybees