### PR TITLE
return stdout of docker push

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -164,7 +164,7 @@ class Docker implements Serializable {
                 // The image may have already been tagged, so the tagging may be a no-op.
                 // That's ok since tagging is cheap.
                 def taggedImageName = tag(tagName, force)
-                docker.script.sh "docker push ${taggedImageName}"
+                docker.script.sh (script:  "docker push ${taggedImageName}", returnStdout: true).trim()
             }
         }
 


### PR DESCRIPTION
Push log contains digest information which generated by docker registry. Return the push log so that developer can get the digest for deployment