### PR TITLE
Reorder args to come after default args for docker run

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -99,10 +99,6 @@ public class DockerClient {
         ArgumentListBuilder argb = new ArgumentListBuilder();
 
         argb.add("run", "-t", "-d", "-u", user);
-        if (args != null) {
-            argb.addTokenized(args);
-        }
-        
         if (workdir != null) {
             argb.add("-w", workdir);
         }
@@ -116,7 +112,11 @@ public class DockerClient {
             argb.add("-e");
             argb.addMasked(variable.getKey()+"="+variable.getValue());
         }
-        argb.add("--entrypoint").add(entrypoint).add(image);
+        argb.add("--entrypoint").add(entrypoint);
+        if (args != null) {
+            argb.addTokenized(args);
+        }
+        argb.add(image);
 
         LaunchResult result = launch(launchEnv, false, null, argb);
         if (result.getStatus() == 0) {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -244,11 +244,10 @@ public class WithContainerStepTest {
                 p.setDefinition(new CpsFlowDefinition(
                         "node {\n" +
                         "  withDockerContainer('ubuntu') {\n" +
-                        "    sh 'cat /proc/1/cmdline'\n" +
+                        "    sh 'grep cat /proc/1/cmdline'\n" +
                         "  }\n" +
                         "}", true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                story.j.assertLogContains("cat", b);
             }
         });
     }
@@ -260,12 +259,11 @@ public class WithContainerStepTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
                         "node {\n" +
-                        "  withDockerContainer(args: '--entrypoint top', image: 'ubuntu') {\n" +
-                        "    sh 'cat /proc/1/cmdline'\n" +
+                        "  withDockerContainer(args: '--entrypoint /sbin/init', image: 'ubuntu') {\n" +
+                        "    sh 'grep /sbin/init /proc/1/cmdline'\n" +
                         "  }\n" +
                         "}", true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                story.j.assertLogContains("top", b);
             }
         });
     }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -236,4 +236,38 @@ public class WithContainerStepTest {
         });
     }
 
+    @Test public void defaultEntrypoint() throws Exception {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                DockerTestUtil.assumeDocker();
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
+                p.setDefinition(new CpsFlowDefinition(
+                        "node {\n" +
+                        "  withDockerContainer('ubuntu') {\n" +
+                        "    sh 'cat /proc/1/cmdline'\n" +
+                        "  }\n" +
+                        "}", true));
+                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                story.j.assertLogContains("cat", b);
+            }
+        });
+    }
+
+    @Test public void allowRunOverrides() throws Exception {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                DockerTestUtil.assumeDocker();
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
+                p.setDefinition(new CpsFlowDefinition(
+                        "node {\n" +
+                        "  withDockerContainer(args: '--entrypoint top', image: 'ubuntu') {\n" +
+                        "    sh 'cat /proc/1/cmdline'\n" +
+                        "  }\n" +
+                        "}", true));
+                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                story.j.assertLogContains("top", b);
+            }
+        });
+    }
+
 }


### PR DESCRIPTION
Reorder the arguments to allow for user specified arguments to come after all of the hardcoded arguments.

This will allow you to workaround some issues that were created in #63 by allowing you to override items such as entrypoint which may be required for some containers (i.e. systemd must be pid 1).

Before:

```
docker run <default_args> <user_args> <default_args> <image>
```

After:

```
docker run <default_args> <user_args> <image>
```

I added tests, but was unable to validate them due to the error below, seems that it is a [known issue](https://issues.jenkins-ci.org/browse/JENKINS-33962) for docker-machine.

```
[prj] Running shell script
sh: 1: cannot create /var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit4687256505953296942/junit1220044917864205478/workspace/prj@tmp/durable-b7f04670/pid: Directory nonexistent
sh: 1: cannot create /var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit4687256505953296942/junit1220044917864205478/workspace/prj@tmp/durable-b7f04670/jenkins-log.txt: Directory nonexistent
sh: 1: cannot create /var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit4687256505953296942/junit1220044917864205478/workspace/prj@tmp/durable-b7f04670/jenkins-result.txt: Directory nonexistent
[Pipeline] }
```

Output from tests:

```
before:
[prj #1] $ docker run -t -d -u 831285540:20 --entrypoint top -w
/var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit6294743115081687909/junit1069789762294073878/workspace/prj
-v
/var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit6294743115081687909/junit1069789762294073878/workspace/prj:/var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit6294743115081687909/junit1069789762294073878/workspace/prj:rw
-v
/var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit6294743115081687909/junit1069789762294073878/workspace/prj@tmp:/var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit6294743115081687909/junit1069789762294073878/workspace/prj@tmp:rw
-e ******** -e ******** -e ******** -e ******** -e ******** -e ********
-e ******** -e ******** -e ******** -e ******** -e ******** -e ********
-e ******** -e ******** -e ******** -e ******** --entrypoint cat ubuntu

after:
[prj #1] $ docker run -t -d -u 831285540:20 -w
/var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit4564385658999144660/junit4862643704887102551/workspace/prj
-v
/var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit4564385658999144660/junit4862643704887102551/workspace/prj:/var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit4564385658999144660/junit4862643704887102551/workspace/prj:rw
-v
/var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit4564385658999144660/junit4862643704887102551/workspace/prj@tmp:/var/folders/p6/66k97xvd7jl2ttk9wgmq2z9hrrrt94/T/junit4564385658999144660/junit4862643704887102551/workspace/prj@tmp:rw
-e ******** -e ******** -e ******** -e ******** -e ******** -e ********
-e ******** -e ******** -e ******** -e ******** -e ******** -e ********
-e ******** -e ******** -e ******** -e ******** --entrypoint cat
--entrypoint top ubuntu
```

cc: @jglick 
