### PR TITLE
[JENKINS-38018] Call newly available API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-commons</artifactId>
-            <version>1.3.1</version>
+            <version>1.5-SNAPSHOT</version> <!-- https://github.com/jenkinsci/docker-commons-plugin/pull/55 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/RegistryEndpointStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/RegistryEndpointStep.java
@@ -26,7 +26,9 @@ package org.jenkinsci.plugins.docker.workflow;
 import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.Launcher;
 import hudson.model.Job;
+import hudson.model.TaskListener;
 import java.io.IOException;
 import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
@@ -56,9 +58,11 @@ public class RegistryEndpointStep extends AbstractStepImpl {
         @Inject(optional=true) private transient RegistryEndpointStep step;
         @StepContextParameter private transient Job<?,?> job;
         @StepContextParameter private transient FilePath workspace;
+        @StepContextParameter private transient Launcher launcher;
+        @StepContextParameter private transient TaskListener listener;
 
         @Override protected KeyMaterialFactory newKeyMaterialFactory() throws IOException, InterruptedException {
-            return step.registry.newKeyMaterialFactory(job, workspace.getChannel());
+            return step.registry.newKeyMaterialFactory(job, workspace.getChannel(), launcher, listener);
         }
 
     }


### PR DESCRIPTION
Provides better diagnostics for [JENKINS-38018](https://issues.jenkins-ci.org/browse/JENKINS-38018).

Downstream of https://github.com/jenkinsci/docker-commons-plugin/pull/55.

See also #71.

@reviewbybees