### PR TITLE
[JENKINS-38835] Fix up demo so that 'make -C demo run' sort of works on OSX

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -46,3 +46,12 @@ COPY run-demo.sh /usr/local/bin/run-demo.sh
 ENV JAVA_OPTS -Djenkins.install.state=INITIAL_SECURITY_SETUP
 
 CMD /usr/local/bin/run-demo.sh
+
+RUN \
+    apt-get update && \
+    apt-get install -y apt-transport-https ca-certificates && \
+    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
+    echo "deb https://apt.dockerproject.org/repo debian-jessie main" > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y docker-engine
+    

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -55,7 +55,9 @@ build:	copy-plugins build-registry
 #	
 # If using boot2docker, you need to tell your remote debugger to use the boot2docker VM ip (ala boot2docker ip).
 
-DOCKER_RUN=docker run --rm -p 127.0.0.1:8080:8080 -v $(shell which docker):/usr/bin/docker -v /var/run/docker.sock:/var/run/docker.sock --group-add=$(shell stat -c %g /var/run/docker.sock)
+STAT=$(firstword $(shell which gstat) $(shell which stat))
+
+DOCKER_RUN=docker run --rm -p 127.0.0.1:8080:8080 -v /var/run/docker.sock:/var/run/docker.sock --group-add=$(shell $(STAT) -c %g /var/run/docker.sock)
 
 run:	build
 	$(DOCKER_RUN) $(IMAGE):$(TAG)


### PR DESCRIPTION
[JENKINS-38835](https://issues.jenkins-ci.org/browse/JENKINS-38835)

Install docker into the workflow-demo, prefer gstat vs stat.
Still a problem with downloading the jenkins plugins from maven.
