### PR TITLE
Allowing manual control over containers capable of running inside jobs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/ImageNameTokens.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/ImageNameTokens.java
@@ -62,4 +62,11 @@ public class ImageNameTokens implements Serializable {
             this.tag = "latest";
         }
     }
+
+    @Whitelisted
+    public ImageNameTokens(@Nonnull String userAndRepo, String tag) {
+        this.userAndRepo = userAndRepo;
+        this.tag = tag;
+    }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/InsideContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/InsideContainerStep.java
@@ -1,0 +1,166 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.workflow;
+
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.docker.workflow.client.DockerClient;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import com.google.inject.Inject;
+
+import hudson.AbortException;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.LauncherDecorator;
+import hudson.Util;
+import hudson.model.Computer;
+import hudson.model.Node;
+import hudson.model.TaskListener;
+import hudson.util.VersionNumber;
+
+public class InsideContainerStep extends AbstractStepImpl {
+
+    private static final Logger LOGGER = Logger.getLogger(WithContainerStep.class.getName());
+    private final
+    @Nonnull
+    String containerId;
+    private String toolName;
+
+    @DataBoundConstructor
+    public InsideContainerStep(@Nonnull String containerId) {
+        this.containerId = containerId;
+    }
+
+    public String getContainerId() {
+        return containerId;
+    }
+
+    public String getToolName() {
+        return toolName;
+    }
+
+    @DataBoundSetter
+    public void setToolName(String toolName) {
+        this.toolName = Util.fixEmpty(toolName);
+    }
+
+    public static class Execution extends AbstractStepExecutionImpl {
+
+        @Inject(optional = true) private transient InsideContainerStep step;
+        @StepContextParameter private transient Launcher launcher;
+        @StepContextParameter private transient TaskListener listener;
+        @StepContextParameter private transient FilePath workspace;
+        @StepContextParameter private transient EnvVars env;
+        @StepContextParameter private transient Computer computer;
+        @StepContextParameter private transient Node node;
+        private String toolName;
+
+        @Override
+        public boolean start() throws Exception {
+            DockerClient dockerClient = new DockerClient(launcher, node, toolName);
+
+            // Add a warning if the docker version is less than 1.4
+            VersionNumber dockerVersion = dockerClient.version();
+            if (dockerVersion != null) {
+                if (dockerVersion.isOlderThan(new VersionNumber("1.4"))) {
+                    throw new AbortException(
+                        "The docker version is less than v1.4. Pipeline functions requiring 'docker exec' will not work e.g. 'docker.inside'.");
+                }
+            } else {
+                listener.error(
+                    "Failed to parse docker version. Please note there is a minimum docker version requirement of v1.4.");
+            }
+
+            getContext()
+                .newBodyInvoker()
+                .withContext(BodyInvoker.mergeLauncherDecorators(
+                    getContext().get(LauncherDecorator.class),
+                    new WithContainerStep.Decorator(step.containerId, computer.getEnvironment(), workspace.getRemote(),
+                        toolName))
+                )
+                .withCallback(new LogFinishCallback())
+                .start();
+
+            return false;
+        }
+
+        @Override
+        public void stop(@Nonnull Throwable cause) throws Exception {
+        }
+    }
+
+    private static class LogFinishCallback extends BodyExecutionCallback.TailCall {
+
+        @Override
+        protected void finished(StepContext context) throws Exception {
+            TaskListener listener = context.get(TaskListener.class);
+            if (listener != null) {
+                listener.getLogger().print("Task finished");
+            }
+        }
+
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(Execution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "insideDockerContainer";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Run build steps inside running Docker container";
+        }
+
+        @Override
+        public boolean takesImplicitBlockArgument() {
+            return true;
+        }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/RunContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/RunContainerStep.java
@@ -1,0 +1,209 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.workflow;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints;
+import org.jenkinsci.plugins.docker.workflow.client.DockerClient;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+
+import hudson.AbortException;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.Computer;
+import hudson.model.Node;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.slaves.WorkspaceList;
+import hudson.util.VersionNumber;
+
+public class RunContainerStep extends AbstractStepImpl {
+
+    private static final Logger LOGGER = Logger.getLogger(WithContainerStep.class.getName());
+    private final @Nonnull String image;
+    private String args;
+    private String toolName;
+    private String command;
+
+    @DataBoundConstructor
+    public RunContainerStep(@Nonnull String image) {
+        this.image = image;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    @DataBoundSetter
+    public void setArgs(String args) {
+        this.args = Util.fixEmpty(args);
+    }
+
+    public String getArgs() {
+        return args;
+    }
+
+    @DataBoundSetter
+    public void setToolName(String toolName) {
+        this.toolName = Util.fixEmpty(toolName);
+    }
+
+    public String getToolName() {
+        return toolName;
+    }
+
+    @DataBoundSetter
+    public void setCommand(String command) {
+        this.command = command;
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+
+    public static class Execution extends AbstractSynchronousNonBlockingStepExecution<String> {
+
+        private static final long serialVersionUID = 1;
+        @Inject(optional = true) private transient RunContainerStep step;
+        @StepContextParameter private transient Launcher launcher;
+        @StepContextParameter private transient TaskListener listener;
+        @StepContextParameter private transient FilePath workspace;
+        @StepContextParameter private transient EnvVars env;
+        @StepContextParameter private transient Computer computer;
+        @StepContextParameter private transient Node node;
+        @SuppressWarnings("rawtypes")
+        @StepContextParameter private transient Run run;
+        private String container;
+        private String toolName;
+
+        @Override
+        protected String run() throws Exception {
+            EnvVars envReduced = new EnvVars(env);
+            EnvVars envHost = computer.getEnvironment();
+            envReduced.entrySet().removeAll(envHost.entrySet());
+            LOGGER.log(Level.FINE, "reduced environment: {0}", envReduced);
+            workspace.mkdirs();
+            String ws = workspace.getRemote();
+            toolName = step.toolName;
+            DockerClient dockerClient = new DockerClient(launcher, node, toolName);
+
+            VersionNumber dockerVersion = dockerClient.version();
+            if (dockerVersion != null) {
+                if (dockerVersion.isOlderThan(new VersionNumber("1.4"))) {
+                    throw new AbortException(
+                        "The docker version is less than v1.4. Pipeline functions requiring 'docker exec' will not work e.g. 'docker.inside'.");
+                }
+            } else {
+                listener.error(
+                    "Failed to parse docker version. Please note there is a minimum docker version requirement of v1.4.");
+            }
+
+            FilePath tempDir = tempDir(workspace);
+            tempDir.mkdirs();
+            String tmp = tempDir.getRemote();
+
+            Map<String, String> volumes = new LinkedHashMap<String, String>();
+            Collection<String> volumesFromContainers = new LinkedHashSet<String>();
+            Optional<String> containerId = dockerClient.getContainerIdIfContainerized();
+            if (containerId.isPresent()) {
+                final Collection<String> mountedVolumes = dockerClient.getVolumes(envHost, containerId.get());
+                final String[] dirs = {ws, tmp};
+                for (String dir : dirs) {
+                    boolean found = false;
+                    for (String vol : mountedVolumes) {
+                        if (dir.startsWith(vol)) {
+                            volumesFromContainers.add(containerId.get());
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        volumes.put(dir, dir);
+                    }
+                }
+            } else {
+                volumes.put(ws, ws);
+                volumes.put(tmp, tmp);
+            }
+
+            String command = (step.command == null || step.command.trim().length() == 0) ? "cat" : step.command;
+
+            container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced,
+                dockerClient.whoAmI(), command);
+            DockerFingerprints.addRunFacet(dockerClient.getContainerRecord(env, container), run);
+            ImageAction.add(step.image, run);
+            return container;
+        }
+
+        private static FilePath tempDir(FilePath ws) {
+            return ws.sibling(ws.getName() + System.getProperty(WorkspaceList.class.getName(), "@") + "tmp");
+        }
+
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(Execution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "runDockerContainer";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Run build steps inside a Docker container";
+        }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+
+    }
+
+
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -196,7 +196,7 @@ public class WithContainerStep extends AbstractStepImpl {
 
     }
 
-    private static class Decorator extends LauncherDecorator implements Serializable {
+    static class Decorator extends LauncherDecorator implements Serializable {
 
         private static final long serialVersionUID = 1;
         private final String container;

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
@@ -35,6 +35,14 @@
                 If unspecified, <code>docker</code> is assumed to be in the <code>$PATH</code> of the slave agent.
             </p>
         </dd>
+        <dt><code>images()</code></dt>
+        <dd>
+            <p>
+                Creates an <code>Images</code> object which reflects all images available in the system. Created object is a snapshot
+                of available images. It is not linked with docker daemon, therefore building new images or pulling new ones will not
+                update this object. To refresh the Images object one needs to call <code>docker.images()</code> again.
+            </p>
+        </dd>
         <dt><code>image(id)</code></dt>
         <dd>
             <p>
@@ -50,10 +58,28 @@
                 Records a <code>FROM</code> fingerprint in the build.
             </p>
         </dd>
+        <dt><code>Images.findFirst {…}</code></dt>
+        <dd>
+            <p>
+                Allows to search through available images in the system. First image matched by provided body will be returned.
+            </p>
+        </dd>
         <dt><code>Image.id</code></dt>
         <dd>
             <p>
                 The image name with optional tag (<code>mycorp/myapp</code>, <code>mycorp/myapp:latest</code>) or ID (hexadecimal hash).
+            </p>
+        </dd>
+        <dt><code>Image.getUserAndRepo()</code></dt>
+        <dd>
+            <p>
+                The image user and repository if it was possible to parse it.
+            </p>
+        </dd>
+        <dt><code>Image.getTag()</code></dt>
+        <dd>
+            <p>
+                The image tag if it was possible to parse it.
             </p>
         </dd>
         <dt><code>Image.run([args, command])</code></dt>
@@ -63,6 +89,12 @@
                 Additional <code>args</code> may be added, such as <code>'-p 8080:8080 --memory-swap=-1'</code>.
                 Optional <code>command</code> is equivalent to Docker command specified after the image.
                 Records a run fingerprint in the build.
+            </p>
+        </dd>
+        <dt><code>Image.runForInsideJob([args, command])</code></dt>
+        <dd>
+            <p>
+                Similar to run but in addition set the container up to allow job executions inside it.
             </p>
         </dd>
         <dt><code>Image.withRun[(args[, command])] {…}</code></dt>
@@ -110,6 +142,21 @@
         <dd>
             <p>
                 Hexadecimal ID of a running container.
+            </p>
+        </dd>
+        <dt><code>Container.inside {…}</code></dt>
+        <dd>
+            <p>
+                Like <code>Image.inside</code> allows to run external commands (<code>sh</code>) launched by the body to run inside the container rather than on the host.
+                These commands run in the same working directory (normally a slave workspace), which means that the Docker server must be on localhost.
+                Important note: this container will not be stopped after the body exits. This way it is possible to use the same container for
+                another jobs or, if it is needed, to persist its state with <code>Container.commit</code>.
+            </p>
+        </dd>
+        <dt><code>Container.commit(name, [params])</code></dt>
+        <dd>
+            <p>
+                Commits this container with the given <code>name</code> using optional parameters.
             </p>
         </dd>
         <dt><code>Container.stop</code></dt>


### PR DESCRIPTION
The idea behind my commit is that it would be nice to allow users to start container once, execute commands in it couple of times and once all of them complete allow them to commit such container. This is essential in creating incremental builds where one image servers as an entry point to another build.
