### PR TITLE
updating display name of plugin to remove CloudBees from name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-CloudBees Docker Pipeline Plugin
+Docker Pipeline Plugin
 =====================================
 
 Jenkins plugin which allows building, testing, and using Docker images from Jenkins Pipeline projects.
@@ -6,7 +6,7 @@ Jenkins plugin which allows building, testing, and using Docker images from Jenk
 Summary
 ---
 
-A full description is available in the plugin’s [documentation](https://go.cloudbees.com/docs/cloudbees-documentation/cje-user-guide/chapter-docker-workflow.html).
+A full description is available in the plugin’s [documentation](https://go.cloudbees.com/docs/cloudbees-documentation/cje-user-guide/index.html#docker-workflow).
 
 Demo
 ---

--- a/demo/JENKINS_HOME/jobs/docker-workflow/config.xml
+++ b/demo/JENKINS_HOME/jobs/docker-workflow/config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <flow-definition>
   <actions/>
-  <description>Demonstrates Jenkins Pipeline integration with Docker based on the CloudBees Docker Pipeline Plugin.</description>
+  <description>Demonstrates Jenkins Pipeline integration with Docker based on the Docker Pipeline Plugin.</description>
   <keepDependencies>false</keepDependencies>
   <properties/>
   <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition">

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,7 +1,7 @@
 Docker image for Docker Pipeline demo
 =====================================
 This image contains a "Docker Pipeline" Job that demonstrates Jenkins Pipeline integration
-with Docker via [CloudBees Docker Pipeline](https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Pipeline+Plugin) plugin.
+with Docker via [Docker Pipeline](https://wiki.jenkins-ci.org/display/JENKINS/Docker+Pipeline+Plugin) plugin.
 
 ```
 docker run --rm -p 127.0.0.1:8080:8080 -v $(which docker):/usr/bin/docker -v /var/run/docker.sock:/var/run/docker.sock --group-add=$(stat -c %g /var/run/docker.sock) jenkinsci/docker-workflow-demo

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <artifactId>docker-workflow</artifactId>
     <version>1.10-SNAPSHOT</version>
-    <name>CloudBees Docker Pipeline</name>
+    <name>Docker Pipeline</name>
     <description>Build and use Docker containers from pipelines</description>
     <packaging>hpi</packaging>
     
@@ -20,7 +20,7 @@
       </license>
     </licenses>
     
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Pipeline+Plugin</url>
+    <url>http://wiki.jenkins-ci.org/display/JENKINS/Docker+Pipeline+Plugin</url>
     <scm>
       <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
       <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>


### PR DESCRIPTION
Will update the plugin wiki page when these changes take effect.

The link to the documentation page has been updated as well to reflect the most recent changes.

@reviewbybees 

