### PR TITLE
[JENKINS-33632] Add a warning if the detected docker version is less than v1.8

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -136,6 +136,8 @@ public class WithContainerStep extends AbstractStepImpl {
             if (dockerVersion != null) {
                 if (dockerVersion.isOlderThan(new VersionNumber("1.4"))) {
                     throw new AbortException("The docker version is less than v1.4. Pipeline functions requiring 'docker exec' will not work e.g. 'docker.inside'.");
+                } else if (dockerVersion.isOlderThan(new VersionNumber("1.8"))) {
+                    listener.error("The docker version is less than v1.8. Running a 'docker.inside' from inside a container will not work.");
                 }
             } else {
                 listener.error("Failed to parse docker version. Please note there is a minimum docker version requirement of v1.4.");


### PR DESCRIPTION
It will warn people that docker.inside running from inside a container will not work in their case.

As seen in [this issue](https://issues.jenkins-ci.org/browse/JENKINS-33632), format of docker inspect [changed for volumes in docker 1.8 ](https://github.com/docker/docker/pull/13711).