### PR TITLE
Making the plugin work also in Docker UCP

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -114,7 +114,7 @@ class Docker implements Serializable {
         
         public <V> V inside(String args = '', Closure<V> body) {
             docker.node {
-                if (docker.script.sh(script: "docker inspect -f . ${id}", returnStatus: true) != 0) {
+                if (docker.script.sh(script: "docker inspect --type image ${id}", returnStatus: true) != 0) {
                     // Not yet present locally.
                     // withDockerContainer requires the image to be available locally, since its start phase is not a durable task.
                     pull()


### PR DESCRIPTION
'docker inspect -f . ${id}' does not work in Docker UCP so we use the '--type image' option that works in Docker Swarm and Docker UCP