### PR TITLE
Fix Jenkins running inside docker (inside docker)*n

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -68,8 +68,9 @@ public class DockerClient {
      * 
      * 4:cpuset:/system.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope
      * 2:cpu:/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
+     * 10:cpu,cpuacct:/docker/a9f3c3932cd81c4a74cc7e0a18c3300255159512f1d000545c42895adaf68932/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
      */
-    public static final String CGROUP_MATCHER_PATTERN = "(?m)^\\d+:\\w+:(?:/[\\w\\.]+)?/docker[-/](?<containerId>\\p{XDigit}{12,})(?:\\.scope)?$";
+    public static final String CGROUP_MATCHER_PATTERN = "(?m)^\\d+:[\\w,?]+:(?:/[\\w.]+)?(/docker[-/](?<containerId>\\p{XDigit}{12,}))+(?:\\.scope)?$";
 
     private Launcher launcher;
     private final @CheckForNull Node node;
@@ -306,7 +307,7 @@ public class DockerClient {
         }
         String cgroup = cgroupFile.readToString();
         Matcher matcher = pattern.matcher(cgroup);
-        return matcher.find() ? Optional.of(matcher.group(1)) : Optional.<String>absent();
+        return matcher.find() ? Optional.of(matcher.group(matcher.groupCount())) : Optional.<String>absent();
     }
 
     public ContainerRecord getContainerRecord(@Nonnull EnvVars launchEnv, String containerId) throws IOException, InterruptedException {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
@@ -95,14 +95,15 @@ public class DockerClientTest {
     	
     	final String[] possibleCgroupStrings = new String[] {
     		"2:cpu:/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
-    		"4:cpuset:/system.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope"
+    		"4:cpuset:/system.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope",
+    		"10:cpu,cpuacct:/docker/a9f3c3932cd81c4a74cc7e0a18c3300255159512f1d000545c42895adaf68932/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b"
     	};
     	
     	for (final String possibleCgroupString : possibleCgroupStrings) {
     		final Pattern pattern = Pattern.compile(DockerClient.CGROUP_MATCHER_PATTERN);
     		Matcher matcher = pattern.matcher(possibleCgroupString);
     		Assert.assertTrue(matcher.find());
-    		Assert.assertEquals("3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b", matcher.group(1));
+    		Assert.assertEquals("3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b", matcher.group(matcher.groupCount()));
 		}
     	
     }


### PR DESCRIPTION
For example in RancherOS etc.
* allow stacked cgroups /docker/ID/docker/ID
* always use the last ID as container ID
* allow grouped cgroups (cpu,cpuacct)
* fix unnecessary escape