### PR TITLE
[JENKINS-38835] Make demo work on newer docker versions and OS X

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -26,6 +26,20 @@ FROM jenkinsci/workflow-demo:2.4
 
 USER root
 
+# Install Docker client
+ENV DOCKER_BUCKET get.docker.com
+ENV DOCKER_VERSION 1.12.1
+ENV DOCKER_SHA256 05ceec7fd937e1416e5dce12b0b6e1c655907d349d52574319a1e875077ccb79
+
+RUN set -x \
+	&& curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-$DOCKER_VERSION.tgz" -o docker.tgz \
+	&& echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
+	&& tar -xzvf docker.tgz \
+	&& mv docker/* /usr/local/bin/ \
+	&& rmdir docker \
+	&& rm docker.tgz \
+	&& docker -v
+
 ADD repo /tmp/repo
 RUN git config --global user.email "demo@jenkins-ci.org" && git config --global user.name "Docker Workflow Demo" && cd /tmp/repo && git init && git add . && git commit -m 'demo'
 

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -55,7 +55,13 @@ build:	copy-plugins build-registry
 #	
 # If using boot2docker, you need to tell your remote debugger to use the boot2docker VM ip (ala boot2docker ip).
 
-DOCKER_RUN=docker run --rm -p 127.0.0.1:8080:8080 -v $(shell which docker):/usr/bin/docker -v /var/run/docker.sock:/var/run/docker.sock --group-add=$(shell stat -c %g /var/run/docker.sock)
+ifeq ($(shell uname -s),Darwin)
+    STAT_OPT = -f
+else
+    STAT_OPT = -c
+endif
+
+DOCKER_RUN=docker run --rm -p 127.0.0.1:8080:8080 -v /var/run/docker.sock:/var/run/docker.sock --group-add=$(shell stat $(STAT_OPT) %g /var/run/docker.sock)
 
 run:	build
 	$(DOCKER_RUN) $(IMAGE):$(TAG)

--- a/demo/README.md
+++ b/demo/README.md
@@ -3,8 +3,15 @@ Docker image for Docker Pipeline demo
 This image contains a "Docker Pipeline" Job that demonstrates Jenkins Pipeline integration
 with Docker via [Docker Pipeline](https://wiki.jenkins-ci.org/display/JENKINS/Docker+Pipeline+Plugin) plugin.
 
+Linux:
+
 ```
-docker run --rm -p 127.0.0.1:8080:8080 -v $(which docker):/usr/bin/docker -v /var/run/docker.sock:/var/run/docker.sock --group-add=$(stat -c %g /var/run/docker.sock) jenkinsci/docker-workflow-demo
+docker run --rm -p 127.0.0.1:8080:8080 -v /var/run/docker.sock:/var/run/docker.sock --group-add=$(stat -c %g /var/run/docker.sock) jenkinsci/docker-workflow-demo
+```
+OS X:
+
+```
+docker run --rm -p 127.0.0.1:8080:8080 -v /var/run/docker.sock:/var/run/docker.sock --group-add=$(stat -f %g /var/run/docker.sock) jenkinsci/docker-workflow-demo
 ```
 
 The "Docker Pipeline" Job simply does the following:


### PR DESCRIPTION
In new Docker versions mounting the docker binary is not enough, the client needs to be installed
OS X stat parameters change slightly

Fixes #73