### PR TITLE
[JENKINS-34276] Allow Image.inside to run with either a local or registry-prefixed name

### DIFF
--- a/demo/JENKINS_HOME/jobs/puller/config.xml
+++ b/demo/JENKINS_HOME/jobs/puller/config.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.9">
+  <actions/>
+  <description>JENKINS-34276 verification; run after docker-workflow #1</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+      <triggers/>
+    </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+  </properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.23">
+    <script>node {
+    echo 'Start with an empty local cache:'
+    sh &apos;(docker images -q examplecorp/spring-petclinic; docker images -q localhost/examplecorp/spring-petclinic) | xargs docker rmi --no-prune=true --force || :&apos;
+    docker.withRegistry(&apos;https://localhost/&apos;, &apos;docker-registry-login&apos;) {
+        echo 'Missing initially, should pull and get latest tag:'
+        docker.image(&apos;examplecorp/spring-petclinic&apos;).inside {
+            sh &apos;ls -l /tomcat7/webapps/petclinic.war&apos;
+        }
+        echo 'This time it should be in local cache and not need to pull:'
+        docker.image(&apos;examplecorp/spring-petclinic&apos;).inside {}
+    }
+}</script>
+    <sandbox>true</sandbox>
+  </definition>
+  <triggers/>
+</flow-definition>

--- a/demo/plugins.txt
+++ b/demo/plugins.txt
@@ -1,5 +1,5 @@
 org.jenkins-ci.plugins:authentication-tokens:1.3
 org.jenkins-ci.plugins:docker-commons:1.5
-org.jenkins-ci.plugins:docker-workflow:1.9
+org.jenkins-ci.plugins:docker-workflow:1.10-SNAPSHOT
 org.jenkins-ci.plugins.icon-shim:icon-shim:2.0.3
 org.jenkins-ci.plugins:xvnc:1.24


### PR DESCRIPTION
[JENKINS-34276](https://issues.jenkins-ci.org/browse/JENKINS-34276)

Perhaps supersedes #51, though the ultimate goal remains unclear. I am not entirely comfortable with this fix, as the original goal of `imageName`—to make usage of custom registries transparent—is unmet, and may be unattainable.

My inclination is to deprecate the whole DSL as more confusing than helpful. It does not add much value beyond the plugin’s provided steps, except this registry prefix handling, and the possibly unused fingerprinting system. Certainly the number of PRs to review would drop; people would be free to share and use public libraries as conveniences, or not.

@reviewbybees