### PR TITLE
[FIXED JENKINS-41316] Switch inside back to cmd, add new method for overriding entrypoint instead

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -76,6 +76,7 @@ public class WithContainerStep extends AbstractStepImpl {
     private final @Nonnull String image;
     private String args;
     private String toolName;
+    private boolean overrideEntrypoint;
 
     @DataBoundConstructor public WithContainerStep(@Nonnull String image) {
         this.image = image;
@@ -92,6 +93,15 @@ public class WithContainerStep extends AbstractStepImpl {
 
     public String getArgs() {
         return args;
+    }
+
+    @DataBoundSetter
+    public void setOverrideEntrypoint(boolean overrideEntrypoint) {
+        this.overrideEntrypoint = overrideEntrypoint;
+    }
+
+    public boolean isOverrideEntrypoint() {
+        return overrideEntrypoint;
     }
 
     public String getToolName() {
@@ -174,7 +184,11 @@ public class WithContainerStep extends AbstractStepImpl {
                 volumes.put(tmp, tmp);
             }
 
-            container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ "cat");
+            if (step.isOverrideEntrypoint()) {
+                container = dockerClient.runWithEntrypoint(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ "cat");
+            } else {
+                container = dockerClient.runWithCommand(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ "cat");
+            }
             DockerFingerprints.addRunFacet(dockerClient.getContainerRecord(env, container), run);
             ImageAction.add(step.image, run);
             getContext().newBodyInvoker().

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -111,8 +111,16 @@ class Docker implements Serializable {
         public String imageName() {
             return toQualifiedImageName(id)
         }
-        
+
         public <V> V inside(String args = '', Closure<V> body) {
+            return insideExecution(false, args, body)
+        }
+
+        public <V> V overrideEntrypoint(String args = '', Closure<V> body) {
+            return insideExecution(true, args, body)
+        }
+
+        private <V> V insideExecution(boolean overrideEntrypoint, String args = '', Closure<V> body) {
             docker.node {
                 def toRun = imageName()
                 if (toRun != id && docker.script.sh(script: "docker inspect -f . ${id}", returnStatus: true) == 0) {
@@ -125,7 +133,7 @@ class Docker implements Serializable {
                         pull()
                     }
                 }
-                docker.script.withDockerContainer(image: toRun, args: args, toolName: docker.script.env.DOCKER_TOOL_NAME) {
+                docker.script.withDockerContainer(image: toRun, args: args, toolName: docker.script.env.DOCKER_TOOL_NAME, overrideEntrypoint: overrideEntrypoint) {
                     body()
                 }
             }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -149,7 +149,7 @@ public class DockerDSLTest {
                 assumeDocker();
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
-                        "docker.image('maven:latest').inside {\n" +
+                        "docker.image('maven:latest').overrideEntrypoint {\n" +
                         "  sh 'mvn -version'\n" +
                         "}", true));
 


### PR DESCRIPTION
[JENKINS-41316](https://issues.jenkins-ci.org/browse/JENKINS-41316)

"First, do no harm" suggests that the earlier behavior, passing a
command to docker when using .inside, was probably preferable to
overriding ENTRYPOINT. But there are definitely cases where overriding
ENTRYPOINT is worthwhile, so here we're adding a new
"docker.image(...).overrideEntrypoint { ... }" method that works the
same as "docker.image(...).inside { ... }" did since JENKINS-37987 was
fixed, while "docker.image(...).inside { ... }" is reverted to its
pre-JENKINS-37987 behavior.

cc @reviewbybees esp @jglick