### PR TITLE
[JENKINS-37719] Apply a timeout to all Docker CLI operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.17</version>
+        <version>2.21</version>
         <relativePath/>
     </parent>
     <artifactId>docker-workflow</artifactId>
@@ -52,37 +52,37 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.17</version>
+            <version>2.25</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.4</version>
+            <version>2.8</version>
         </dependency>
         <dependency> <!-- StepConfigTester -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <classifier>tests</classifier>
-            <version>2.2</version>
+            <version>2.7</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- SemaphoreStep -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <classifier>tests</classifier>
-            <version>2.1</version>
+            <version>2.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.3</version>
+            <version>2.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.0</version>
+            <version>2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -57,6 +57,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 import hudson.util.VersionNumber;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
 import org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints;
 import org.jenkinsci.plugins.docker.commons.tools.DockerTool;
@@ -247,7 +248,7 @@ public class WithContainerStep extends AbstractStepImpl {
                 @Override public void kill(Map<String,String> modelEnvVars) throws IOException, InterruptedException {
                     ByteArrayOutputStream baos = new ByteArrayOutputStream();
                     String executable = getExecutable();
-                    if (getInner().launch().cmds(executable, "exec", container, "ps", "-A", "-o", "pid,command", "e").stdout(baos).quiet(true).join() != 0) {
+                    if (getInner().launch().cmds(executable, "exec", container, "ps", "-A", "-o", "pid,command", "e").stdout(baos).quiet(true).start().joinWithTimeout(10, TimeUnit.SECONDS, listener) != 0) {
                         throw new IOException("failed to run ps");
                     }
                     List<String> pids = new ArrayList<String>();
@@ -269,7 +270,7 @@ public class WithContainerStep extends AbstractStepImpl {
                     if (!pids.isEmpty()) {
                         List<String> cmds = new ArrayList<>(Arrays.asList(executable, "exec", container, "kill"));
                         cmds.addAll(pids);
-                        if (getInner().launch().cmds(cmds).quiet(true).join() != 0) {
+                        if (getInner().launch().cmds(cmds).quiet(true).start().joinWithTimeout(10, TimeUnit.SECONDS, listener) != 0) {
                             throw new IOException("failed to run kill");
                         }
                     }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -45,6 +45,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.List;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -264,7 +265,7 @@ public class DockerClient {
         LaunchResult result = new LaunchResult();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayOutputStream err = new ByteArrayOutputStream();
-        result.setStatus(procStarter.quiet(quiet).cmds(args).envs(launchEnv).stdout(out).stderr(err).join());
+        result.setStatus(procStarter.quiet(quiet).cmds(args).envs(launchEnv).stdout(out).stderr(err).start().joinWithTimeout(10, TimeUnit.SECONDS, launcher.getListener()));
         final String charsetName = Charset.defaultCharset().name();
         result.setOut(out.toString(charsetName));
         result.setErr(err.toString(charsetName));
@@ -278,10 +279,10 @@ public class DockerClient {
      */
     public String whoAmI() throws IOException, InterruptedException {
         ByteArrayOutputStream userId = new ByteArrayOutputStream();
-        launcher.launch().cmds("id", "-u").quiet(true).stdout(userId).join();
+        launcher.launch().cmds("id", "-u").quiet(true).stdout(userId).start().joinWithTimeout(10, TimeUnit.SECONDS, launcher.getListener());
 
         ByteArrayOutputStream groupId = new ByteArrayOutputStream();
-        launcher.launch().cmds("id", "-g").quiet(true).stdout(groupId).join();
+        launcher.launch().cmds("id", "-g").quiet(true).stdout(groupId).start().joinWithTimeout(10, TimeUnit.SECONDS, launcher.getListener());
 
         final String charsetName = Charset.defaultCharset().name();
         return String.format("%s:%s", userId.toString(charsetName).trim(), groupId.toString(charsetName).trim());

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerTestUtil.java
@@ -30,6 +30,7 @@ import hudson.util.VersionNumber;
 import org.junit.Assume;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.is;
 import org.jenkinsci.plugins.docker.commons.tools.DockerTool;
@@ -42,12 +43,14 @@ public class DockerTestUtil {
     public static void assumeDocker() throws Exception {
         Launcher.LocalLauncher localLauncher = new Launcher.LocalLauncher(StreamTaskListener.NULL);
         try {
-            Assume.assumeThat("Docker working", localLauncher.launch().cmds(DockerTool.getExecutable(null, null, null, null), "ps").join(), is(0));
+            Assume.assumeThat("Docker working", localLauncher.launch().cmds(DockerTool.getExecutable(null, null, null, null), "ps").start().joinWithTimeout(10, TimeUnit.SECONDS, localLauncher.getListener()), is(0));
         } catch (IOException x) {
             Assume.assumeNoException("have Docker installed", x);
         }
         DockerClient dockerClient = new DockerClient(localLauncher, null, null);
         Assume.assumeFalse("Docker version not < 1.3", dockerClient.version().isOlderThan(new VersionNumber("1.3")));
     }
+
+    private DockerTestUtil() {}
     
 }


### PR DESCRIPTION
[JENKINS-37719](https://issues.jenkins-ci.org/browse/JENKINS-37719)

https://github.com/jenkinsci/workflow-cps-plugin/pull/102 and https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/30 are also helpful but this patch in isolation suffices to fix the problem, at least to the extent I am able to reproduce it by simply forcing the Docker daemon to hang.

@reviewbybees