### PR TITLE
Print diagnostics to the build log explaining why --volumes-from is or is not being used

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -151,6 +151,7 @@ public class WithContainerStep extends AbstractStepImpl {
             Collection<String> volumesFromContainers = new LinkedHashSet<String>();
             Optional<String> containerId = dockerClient.getContainerIdIfContainerized();
             if (containerId.isPresent()) {
+                listener.getLogger().println(node.getDisplayName() + " seems to be running inside container " + containerId.get());
                 final Collection<String> mountedVolumes = dockerClient.getVolumes(envHost, containerId.get());
                 final String[] dirs = {ws, tmp};
                 for (String dir : dirs) {
@@ -164,12 +165,12 @@ public class WithContainerStep extends AbstractStepImpl {
                         }
                     }
                     if (!found) {
-                        // there was no volume which contains the directory, fall back to --volume mount
+                        listener.getLogger().println("but " + dir + " could not be found among " + mountedVolumes);
                         volumes.put(dir, dir);
                     }
                 }
             } else {
-                // Jenkins is not running inside a container
+                listener.getLogger().println(node.getDisplayName() + " does not seem to be running inside a container");
                 volumes.put(ws, ws);
                 volumes.put(tmp, tmp);
             }


### PR DESCRIPTION
Used in the course of developing https://github.com/jenkinsci/acceptance-test-harness/pull/272. Might be considered too chatty, but given the confusion attending problems like that (purportedly) fixed in #82, it seems better to err on the side of being clear about why we are running in a certain mode.

@reviewbybees