### PR TITLE
Fix for JENKINS-42152 - docker tag fails with Docker 1.12+

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -159,8 +159,15 @@ class Docker implements Serializable {
         public void tag(String tagName = parsedId.tag, boolean force = true) {
             docker.node {
                 def taggedImageName = toQualifiedImageName(parsedId.userAndRepo + ':' + tagName)
-                // TODO as of 1.10.0 --force is deprecated; for 1.12+ do not try it even once
-                docker.script.sh "docker tag --force=${force} ${id} ${taggedImageName} || docker tag ${id} ${taggedImageName}"
+                //get docker version
+                dockerVersion = docker.script.sh(script: "docker version --format '{{.Client.Version}}'", returnStdout: true).trim().split('.')
+                dockerMainVersion = dockerVersion[0].isInteger() ? dockerVersion[0].toInteger() : null
+                dockerMinorVersion = dockerVersion[1].isInteger() ? dockerVersion[1].toInteger() : null
+                if (dockerMainVersion >= 1 && dockerMinorVersion >= 12) {
+                    docker.script.sh "docker tag ${id} ${taggedImageName}"
+                } else {
+                    docker.script.sh "docker tag --force=${force} ${id} ${taggedImageName} || docker tag ${id} ${taggedImageName}"
+                }
                 return taggedImageName;
             }
         }

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -160,9 +160,9 @@ class Docker implements Serializable {
             docker.node {
                 def taggedImageName = toQualifiedImageName(parsedId.userAndRepo + ':' + tagName)
                 //get docker version
-                dockerVersion = docker.script.sh(script: "docker version --format '{{.Client.Version}}'", returnStdout: true).trim().split('.')
-                dockerMainVersion = dockerVersion[0].isInteger() ? dockerVersion[0].toInteger() : null
-                dockerMinorVersion = dockerVersion[1].isInteger() ? dockerVersion[1].toInteger() : null
+                def dockerVersion = docker.script.sh(script: "docker version --format '{{.Client.Version}}'", returnStdout: true).trim().split('.')
+                def dockerMainVersion = dockerVersion[0].isInteger() ? dockerVersion[0].toInteger() : null
+                def dockerMinorVersion = dockerVersion[1].isInteger() ? dockerVersion[1].toInteger() : null
                 if (dockerMainVersion >= 1 && dockerMinorVersion >= 12) {
                     docker.script.sh "docker tag ${id} ${taggedImageName}"
                 } else {


### PR DESCRIPTION
added check for docker client version before executing tag with --force flag