### PR TITLE
[JENKINS-43328] Detect container ID when run with --parent-group

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -70,8 +70,9 @@ public class DockerClient {
      * 4:cpuset:/system.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope
      * 2:cpu:/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
      * 10:cpu,cpuacct:/docker/a9f3c3932cd81c4a74cc7e0a18c3300255159512f1d000545c42895adaf68932/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
+     * 3:cpu:/docker/4193df6bcf5fce75f3fc77f303b2ac06fb664adeb269b959b7ae17b3f8dcf329/14d7240da87b145e4992654c908a8631dbf179abb7f88115ea72743e1192d07d
      */
-    public static final String CGROUP_MATCHER_PATTERN = "(?m)^\\d+:[\\w,?]+:(?:/[\\w.]+)?(/docker[-/](?<containerId>\\p{XDigit}{12,}))+(?:\\.scope)?$";
+    public static final String CGROUP_MATCHER_PATTERN = "(?m)^\\d+:[\\w,?]+:(?:/[\\w.]+)?(?:/docker[-/])(/?(?:docker/)?(?<containerId>\\p{XDigit}{12,}))+(?:\\.scope)?$";
 
     private Launcher launcher;
     private final @CheckForNull Node node;

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
@@ -96,13 +96,14 @@ public class DockerClientTest {
     	final String[] possibleCgroupStrings = new String[] {
     		"2:cpu:/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
     		"4:cpuset:/system.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope",
-    		"10:cpu,cpuacct:/docker/a9f3c3932cd81c4a74cc7e0a18c3300255159512f1d000545c42895adaf68932/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b"
+    		"10:cpu,cpuacct:/docker/a9f3c3932cd81c4a74cc7e0a18c3300255159512f1d000545c42895adaf68932/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
+            "3:cpu:/docker/4193df6bcf5fce75f3fc77f303b2ac06fb664adeb269b959b7ae17b3f8dcf329/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b"
     	};
     	
     	for (final String possibleCgroupString : possibleCgroupStrings) {
     		final Pattern pattern = Pattern.compile(DockerClient.CGROUP_MATCHER_PATTERN);
     		Matcher matcher = pattern.matcher(possibleCgroupString);
-    		Assert.assertTrue(matcher.find());
+    		Assert.assertTrue("pattern didn't matched containerId " + possibleCgroupString, matcher.find());
     		Assert.assertEquals("3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b", matcher.group(matcher.groupCount()));
 		}
     	


### PR DESCRIPTION
[JENKINS-43328](https://issues.jenkins-ci.org/browse/JENKINS-43328)