### PR TITLE
Don't mask the PATH environment variable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -116,7 +116,11 @@ public class DockerClient {
         }
         for (Map.Entry<String, String> variable : containerEnv.entrySet()) {
             argb.add("-e");
-            argb.addMasked(variable.getKey()+"="+variable.getValue());
+            if (variable.getKey().equals("PATH")) {
+                argb.add(variable.getKey()+"="+variable.getValue());
+            } else {
+                argb.addMasked(variable.getKey()+"="+variable.getValue());
+            }
         }
         argb.add("--entrypoint").add(entrypoint).add(image);
 


### PR DESCRIPTION
This should help troubleshooting the "cat not in $PATH" errors.

Example error:

```
docker: Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: \"cat\": executable file not found in $PATH".
```