### PR TITLE
Blacklist EnvVars for docker run -e

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -46,6 +46,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.LinkedHashMap;
@@ -126,7 +127,11 @@ public class WithContainerStep extends AbstractStepImpl {
             EnvVars envReduced = new EnvVars(env);
             EnvVars envHost = computer.getEnvironment();
             envReduced.entrySet().removeAll(envHost.entrySet());
-            LOGGER.log(Level.FINE, "reduced environment: {0}", envReduced);
+
+            // Remove PATH during cat.
+            envReduced.remove("PATH");
+
+            LOGGER.log(Level.FINE, "(cat) reduced environment: {0}", envReduced);
             workspace.mkdirs(); // otherwise it may be owned by root when created for -v
             String ws = workspace.getRemote();
             toolName = step.toolName;
@@ -236,7 +241,17 @@ public class WithContainerStep extends AbstractStepImpl {
                     } // otherwise we are loading an old serialized Decorator
                     Set<String> envReduced = new TreeSet<String>(Arrays.asList(starter.envs()));
                     envReduced.removeAll(Arrays.asList(envHost));
+
+                    // Remove PATH during `exec` as well.
+                    Iterator<String> it = envReduced.iterator();
+                    while (it.hasNext()) {
+                        if (it.next().startsWith("PATH=")) {
+                            it.remove();
+                        }
+                    }
+                    LOGGER.log(Level.FINE, "(exec) reduced environment: {0}", envReduced);
                     prefix.addAll(envReduced);
+
                     // Adapted from decorateByPrefix:
                     starter.cmds().addAll(0, prefix);
                     if (starter.masks() != null) {


### PR DESCRIPTION
This blacklists certain environment variables to be passed into docker
run via the -e flags:

- PATH
- A bunch of LD_ vars

[JENKINS-43590](https://issues.jenkins-ci.org/browse/JENKINS-43590) docker.inside()'s -e flags are random

This is a better solution than #96