### PR TITLE
after pulling a image it is now possible to tag it

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -100,7 +100,7 @@ class Docker implements Serializable {
 
         private Image(Docker docker, String id) {
             this.docker = docker
-            this.id = id
+            this.id = new org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint(docker.script.env.DOCKER_REGISTRY_URL, null).imageName(id)
             this.parsedId = new ImageNameTokens(id)
         }
 
@@ -133,7 +133,7 @@ class Docker implements Serializable {
 
         public void pull() {
             docker.node {
-                docker.script.sh "docker pull ${imageName()}"
+                docker.script.sh "docker pull ${id}"
             }
         }
 


### PR DESCRIPTION
If you pull a Image from a private Registry you can't tag it. 

```
docker.withRegistry("https://docker.bla.de"){
            r_image = docker.image("${docker_image_name}:${dev_image_tag}")
            r_image.pull()
            r_image.tag("current")
        }
```
This happens because the id is used instead of the image name. The id didn't contain the registry. This pull request should fix it. 

Jira Issue: JENKINS-44234