### PR TITLE
remove empty EnvVars to execute 'docker run' command

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -126,6 +126,7 @@ public class WithContainerStep extends AbstractStepImpl {
             EnvVars envReduced = new EnvVars(env);
             EnvVars envHost = computer.getEnvironment();
             envReduced.entrySet().removeAll(envHost.entrySet());
+            envReduced.remove("");
             LOGGER.log(Level.FINE, "reduced environment: {0}", envReduced);
             workspace.mkdirs(); // otherwise it may be owned by root when created for -v
             String ws = workspace.getRemote();


### PR DESCRIPTION
'docker run' command does not work if Jenkins has empty environment variables.

```
java.io.IOException: Failed to run image 'maven:3.3.3'. Error: invalid argument "=" for e: invalid environment variable: =
See 'docker run --help'.
```