### PR TITLE
Stray whitespace in DockerClient.getVolumes format string can cause errors

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -334,7 +334,7 @@ public class DockerClient {
      * @throws InterruptedException Interrupted
      */
     public List<String> getVolumes(@Nonnull EnvVars launchEnv, String containerID) throws IOException, InterruptedException {
-        LaunchResult result = launch(launchEnv, true, "inspect", "-f", "{{range .Mounts}}{{.Destination}}\n{{end}}", containerID);
+        LaunchResult result = launch(launchEnv, true, "inspect", "-f", "{{range.Mounts}}{{.Destination}}\n{{end}}", containerID);
         if (result.getStatus() != 0) {
             return Collections.emptyList();
         }


### PR DESCRIPTION
Removes space from **getVolumes()** format parameter to avoid error as mentioned in issue https://github.com/moby/moby/issues/8792