### PR TITLE
Trim trailing space that interferes with correct || execution

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -158,7 +158,7 @@ class Docker implements Serializable {
 
         public void tag(String tagName = parsedId.tag, boolean force = true) {
             docker.node {
-                def taggedImageName = toQualifiedImageName(parsedId.userAndRepo + ':' + tagName)
+                def taggedImageName = toQualifiedImageName(parsedId.userAndRepo + ':' + tagName).trim()
                 // TODO as of 1.10.0 --force is deprecated; for 1.12+ do not try it even once
                 docker.script.sh "docker tag --force=${force} ${id} ${taggedImageName} || docker tag ${id} ${taggedImageName}"
                 return taggedImageName;


### PR DESCRIPTION
This proposes to address build failures when tagging images on Docker 1.12. Since the ```docker tag --force=true``` option has been removed, that tag command fails with a 125 exit code. The ```|| docker tag``` should then be executed, and tag the image properly, but that doesn't seem to be happening.


Before (1.11):

	Entering stage Push Image to ECR
	Proceeding
	[Pipeline] withEnv
	[Pipeline] {
	[Pipeline] withDockerRegistry
	Wrote authentication to /var/lib/jenkins/.dockercfg
	[Pipeline] {
	[Pipeline] sh
	[prlic] Running shell script

	*** The line below, beginning with the + is echoed by the shell since the shell runs with the -x option. It's particularly noteworthy that the || docker tag command doesn't exist, suggesting that a newline character exists at the end of ${taggedImageName}

	+ docker tag --force=true myimage 410400486419.dkr.ecr.us-east-1.amazonaws.com/myimage:b6860ccf6a4c

	unknown flag: --force
	See 'docker tag --help'.
	[Pipeline] }
	[Pipeline] // withDockerRegistry
	[Pipeline] }
	[Pipeline] // withEnv
	[Pipeline] }
	[Pipeline] // node

After (1.12-SNAPSHOT):

	Entering stage Push Image to ECR
	Proceeding
	[Pipeline] withEnv
	[Pipeline] {
	[Pipeline] withDockerRegistry
	Wrote authentication to /var/lib/jenkins/.dockercfg
	[Pipeline] {
	[Pipeline] sh
	[prlic] Running shell script

	*** The execution below is the same Jenkinsfile after the change proposed. The || in this case results in the execution of the second docker tag command (without --force)

	+ docker tag --force=true myimage 410400486419.dkr.ecr.us-east-1.amazonaws.com/myimage:b6860ccf6a4c
	unknown flag: --force
	See 'docker tag --help'.
	+ docker tag myimage 410400486419.dkr.ecr.us-east-1.amazonaws.com/myimage:b6860ccf6a4c
	[Pipeline] sh
	[prlic] Running shell script
	+ docker push 410400486419.dkr.ecr.us-east-1.amazonaws.com/myimage:b6860ccf6a4c
	The push refers to a repository [410400486419.dkr.ecr.us-east-1.amazonaws.com/myimage]
	0635cdfbcacf: Preparing
	32eb5be8eee7: Preparing
	ff2138030337: Preparing
	a6b48be40b6b: Preparing