### PR TITLE
Handle ARG in FROM that is allowed since Docker 17.05.0

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -79,15 +79,21 @@ class Docker implements Serializable {
 
             // Detect custom Dockerfile:
             def dockerfile = "${dir}/Dockerfile"
+            // Detect build-time variables
+            def buildArgs = []
             for (int i=0; i<parsedArgs.length; i++) {
                 if ((parsedArgs[i] == '-f' || parsedArgs[i] == '--file') && i < (parsedArgs.length - 1)) {
                     dockerfile = parsedArgs[i+1]
-                    break
+                    continue
+                }
+                if (parsedArgs[i] == '--build-arg' && i < (parsedArgs.length - 1)) {
+                    buildArgs.add(parsedArgs[i+1])
+                    continue
                 }
             }
 
             script.sh "docker build -t ${image} ${args}"
-            script.dockerFingerprintFrom dockerfile: dockerfile, image: image, toolName: script.env.DOCKER_TOOL_NAME
+            script.dockerFingerprintFrom dockerfile: dockerfile, image: image, buildArgs: buildArgs, toolName: script.env.DOCKER_TOOL_NAME
             this.image(image)
         }
     }


### PR DESCRIPTION
Since Docker version `17.05.0` it is allowed to use `ARG` variables in `FROM` (see https://github.com/moby/moby/pull/31352 and https://github.com/moby/moby/pull/32486).

This new behavior isn't handled in the plugin so far. This Merge Request implements handling of:
- `ARG`'s that are defined before `FROM` in a Dockerfile (with or without default value).
- `--build-arg`'s that are passed to the `docker build` command.