### PR TITLE
[JENKINS-44609] Use last 'FROM' statement & stop at whitespace in image name

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
@@ -98,8 +98,7 @@ public class FromFingerprintStep extends AbstractStepImpl {
                             continue;
                         }
                         if (line.startsWith("FROM ")) {
-                            fromImage = line.substring(5);
-                            break;
+                            fromImage = line.split(" ")[1];
                         }
                     }
                 } finally {


### PR DESCRIPTION
I wasn't sure how to properly test this, but at least we no longer error out

Fixes: [JENKINS-44609](https://issues.jenkins-ci.org/browse/JENKINS-44609)