### PR TITLE
Check for Kubernetes cgroup name

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -57,7 +57,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Simple docker client for Pipeline.
- * 
+ *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 public class DockerClient {
@@ -73,16 +73,17 @@ public class DockerClient {
 
     // e.g. 2015-04-09T13:40:21.981801679Z
     public static final String DOCKER_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
-    
+
     /**
      * Known cgroup formats
-     * 
+     *
      * 4:cpuset:/system.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope
      * 2:cpu:/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
-     * 10:cpu,cpuacct:/docker/a9f3c3932cd81c4a74cc7e0a18c3300255159512f1d000545c42895adaf68932/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
+     * 10:cpu,cpuacct:/docker  /a9f3c3932cd81c4a74cc7e0a18c3300255159512f1d000545c42895adaf68932/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
      * 3:cpu:/docker/4193df6bcf5fce75f3fc77f303b2ac06fb664adeb269b959b7ae17b3f8dcf329/14d7240da87b145e4992654c908a8631dbf179abb7f88115ea72743e1192d07d
+     * 6:cpu,cpuacct:/kubepods/besteffort/pod87cce21e-5b48-11e7-8f6d-66cd0f9f7717/bc99c8e39cc0336f6c1170a064f51e7bda36de1f1eee4748f1eae5c3be2f2d1d
      */
-    public static final String CGROUP_MATCHER_PATTERN = "(?m)^\\d+:[\\w,?]+:(?:/[\\w.]+)?(?:/docker[-/])(/?(?:docker/)?(?<containerId>\\p{XDigit}{12,}))+(?:\\.scope)?$";
+    public static final String CGROUP_MATCHER_PATTERN = "(?m)^\\d+:[\\w,?]+:(?:/[\\w.]+)?(?:/docker[-/])(/?(?:docker/)?(?:pod[a-z0-9]+/)?(?<containerId>\\p{XDigit}{12,}))+(?:\\.scope)?$";
 
     private final Launcher launcher;
     private final @CheckForNull Node node;
@@ -115,7 +116,7 @@ public class DockerClient {
         if (args != null) {
             argb.addTokenized(args);
         }
-        
+
         if (workdir != null) {
             argb.add("-w", workdir);
         }
@@ -141,10 +142,10 @@ public class DockerClient {
 
     /**
      * Stop a container.
-     * 
-     * <p>                              
+     *
+     * <p>
      * Also removes ({@link #rm(EnvVars, String)}) the container.
-     * 
+     *
      * @param launchEnv Docker client launch environment.
      * @param containerId The container ID.
      */
@@ -158,7 +159,7 @@ public class DockerClient {
 
     /**
      * Remove a container.
-     * 
+     *
      * @param launchEnv Docker client launch environment.
      * @param containerId The container ID.
      */
@@ -185,7 +186,7 @@ public class DockerClient {
             return null;
         }
     }
-    
+
     /**
      * Inspect a docker image/container.
      * @param launchEnv Docker client launch environment.
@@ -196,7 +197,7 @@ public class DockerClient {
      * @throws InterruptedException Interrupted
      * @since 1.1
      */
-    public @Nonnull String inspectRequiredField(@Nonnull EnvVars launchEnv, @Nonnull String objectId, 
+    public @Nonnull String inspectRequiredField(@Nonnull EnvVars launchEnv, @Nonnull String objectId,
             @Nonnull String fieldPath) throws IOException, InterruptedException {
         final String fieldValue = inspect(launchEnv, objectId, fieldPath);
         if (fieldValue == null) {
@@ -204,7 +205,7 @@ public class DockerClient {
         }
         return fieldValue;
     }
-    
+
     private @CheckForNull Date getCreatedDate(@Nonnull EnvVars launchEnv, @Nonnull String objectId) throws IOException, InterruptedException {
         String createdString = inspect(launchEnv, objectId, "json .Created");
         if (createdString == null) {
@@ -233,7 +234,7 @@ public class DockerClient {
             return null;
         }
     }
-    
+
     private static final Pattern pattern = Pattern.compile("^(\\D+)(\\d+)\\.(\\d+)\\.(\\d+)(.*)");
     /**
      * Parse a Docker version string (e.g. "Docker version 1.5.0, build a8a31ef").
@@ -250,7 +251,7 @@ public class DockerClient {
             return new VersionNumber(String.format("%s.%s.%s", major, minor, maint));
         } else {
             return null;
-        }        
+        }
     }
 
     private LaunchResult launch(@Nonnull EnvVars launchEnv, boolean quiet, @Nonnull String... args) throws IOException, InterruptedException {
@@ -330,7 +331,7 @@ public class DockerClient {
 
         // TODO get tags and add for ContainerRecord
         return new ContainerRecord(host, containerId, image, containerName,
-                (created != null ? created.getTime() : 0L), 
+                (created != null ? created.getTime() : 0L),
                 Collections.<String,String>emptyMap());
     }
 


### PR DESCRIPTION
NB: I haven't tested this, and I couldn't find an online regex parser that would match the JAVA semantics.

The client currently only checks for the docker
style of cgroup naming. Kubernetes uses a slightly
different format:

```
$ cat /proc/self/cgroup

11:memory:/kubepods/besteffort/pod87cce21e-5b48-11e7-8f6d-66cd0f9f7717/bc99c8e39cc0336f6c1170a064f51e7bda36de1f1eee4748f1eae5c3be2f2d1d
10:freezer:/kubepods/besteffort/pod87cce21e-5b48-11e7-8f6d-66cd0f9f7717/bc99c8e39cc0336f6c1170a064f51e7bda36de1f1eee4748f1eae5c3be2f2d1d
9:devices:/kubepods/besteffort/pod87cce21e-5b48-11e7-8f6d-66cd0f9f7717/bc99c8e39cc0336f6c1170a064f51e7bda36de1f1eee4748f1eae5c3be2f2d1d
8:blkio:/kubepods/besteffort/pod87cce21e-5b48-11e7-8f6d-66cd0f9f7717/bc99c8e39cc0336f6c1170a064f51e7bda36de1f1eee4748f1eae5c3be2f2d1d
7:hugetlb:/kubepods/besteffort/pod87cce21e-5b48-11e7-8f6d-66cd0f9f7717/bc99c8e39cc0336f6c1170a064f51e7bda36de1f1eee4748f1eae5c3be2f2d1d
6:cpu,cpuacct:/kubepods/besteffort/pod87cce21e-5b48-11e7-8f6d-66cd0f9f7717/bc99c8e39cc0336f6c1170a064f51e7bda36de1f1eee4748f1eae5c3be2f2d1d
5:pids:/kubepods/besteffort/pod87cce21e-5b48-11e7-8f6d-66cd0f9f7717/bc99c8e39cc0336f6c1170a064f51e7bda36de1f1eee4748f1eae5c3be2f2d1d
4:cpuset:/kubepods/besteffort/pod87cce21e-5b48-11e7-8f6d-66cd0f9f7717/bc99c8e39cc0336f6c1170a064f51e7bda36de1f1eee4748f1eae5c3be2f2d1d
3:perf_event:/kubepods/besteffort/pod87cce21e-5b48-11e7-8f6d-66cd0f9f7717/bc99c8e39cc0336f6c1170a064f51e7bda36de1f1eee4748f1eae5c3be2f2d1d
2:net_cls,net_prio:/kubepods/besteffort/pod87cce21e-5b48-11e7-8f6d-66cd0f9f7717/bc99c8e39cc0336f6c1170a064f51e7bda36de1f1eee4748f1eae5c3be2f2d1d
1:name=systemd:/kubepods/besteffort/pod87cce21e-5b48-11e7-8f6d-66cd0f9f7717/bc99c8e39cc0336f6c1170a064f51e7bda36de1f1eee4748f1eae5c3be2f2d1d
```

The CGROUP pattern needs to be updated to accomodate anyone wanting to
talk to the docker daemon on kubernetes hosts.


Note: This is to get 'docker-outside-of-docker' working inside kubernetes. Looks like we may be the only ones doing this, but the idea is that we want to just use the underlying docker daemon wherever we get scheduled on Kubernetes.

Side note: We did try to run the kubernetes-plugin workflow, but found that the caching limitations really held us back.

Extra note: This solves the following output we see when running something like the below:

```
[Pipeline] withDockerContainer
Jenkins does not seem to be running inside a container
$ docker run -t -d -u 0:0 -w /var/jenkins_home/workspace/test -v /var/jenkins_home/workspace/test:/var/jenkins_home/workspace/test:rw,z -v /var/jenkins_home/workspace/test@tmp:/var/jenkins_home/workspace/test@tmp:rw,z -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** --entrypoint cat devth/helm:2.4.2
[Pipeline] {
[Pipeline] sh
[test] Running shell script
sh: can't create /var/jenkins_home/workspace/test@tmp/durable-2bb1c055/pid: nonexistent directory
sh: can't create /var/jenkins_home/workspace/test@tmp/durable-2bb1c055/jenkins-log.txt: nonexistent directory
sh: can't create /var/jenkins_home/workspace/test@tmp/durable-2bb1c055/jenkins-result.txt: nonexistent directory
```

from the job
```
...
    stage("package-helm") {
        withDockerContainer("devth/helm:2.4.2") {
            sh '/bin/helm package --save=false --version $(cat version) charts/catalogue-service'
        }
    }
```