### PR TITLE
[FIXED JENKINS-44609] Docker multi-stage builds no longer throw errors

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
@@ -99,7 +99,7 @@ public class FromFingerprintStep extends AbstractStepImpl {
                         }
                         if (line.startsWith("FROM ")) {
                             fromImage = line.substring(5);
-                            break;
+                            continue;
                         }
                     }
                 } finally {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.docker.workflow;
 
 import static org.jenkinsci.plugins.docker.workflow.DockerTestUtil.assumeDocker;
 
+import hudson.util.VersionNumber;
 import org.jenkinsci.plugins.docker.workflow.client.DockerClient;
 import hudson.EnvVars;
 import hudson.Launcher;
@@ -328,7 +329,7 @@ public class DockerDSLTest {
     @Test public void buildWithMultiStage() {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
-                assumeDocker();
+                assumeDocker(new VersionNumber("17.05"));
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
                         "node {\n" +

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -337,7 +337,16 @@ public class DockerDSLTest {
                                 "  writeFile file: 'child/stuff1', text: 'hello'\n" +
                                 "  writeFile file: 'child/stuff2', text: 'world'\n" +
                                 "  writeFile file: 'child/stuff3', text: env.BUILD_NUMBER\n" +
-                                "  writeFile file: 'child/Dockerfile.other', text: '# This is a test.\\n\\nFROM hello-world AS one\\nARG stuff4=4\\nARG stuff5=5\\nCOPY stuff1 /\\nFROM scratch\\nCOPY --from=one /stuff1 /\\nCOPY stuff2 /\\nCOPY stuff3 /\\n'\n" +
+                                "  writeFile file: 'child/Dockerfile.other', " +
+                                     "text: '# This is a test.\\n" +
+                                            "\\n" +
+                                            "FROM hello-world AS one\\n" +
+                                            "ARG stuff4=4\\n" +
+                                            "ARG stuff5=5\\n" +
+                                            "COPY stuff1 /\\n" +
+                                            "FROM scratch\\n" +
+                                            "COPY --from=one /stuff1 /\\n" +
+                                            "COPY stuff2 /\\nCOPY stuff3 /\\n'\n" +
                                 "  def built = docker.build 'hello-world-stuff-arguments', '-f child/Dockerfile.other --build-arg stuff4=build4 --build-arg stuff5=build5 child'\n" +
                                 "  echo \"built ${built.id}\"\n" +
                                 "}", true));

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerTestUtil.java
@@ -39,8 +39,13 @@ import org.jenkinsci.plugins.docker.commons.tools.DockerTool;
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 public class DockerTestUtil {
-    
+    public static String DEFAULT_MINIMUM_VERSION = "1.3";
+
     public static void assumeDocker() throws Exception {
+        assumeDocker(new VersionNumber(DEFAULT_MINIMUM_VERSION));
+    }
+    
+    public static void assumeDocker(VersionNumber minimumVersion) throws Exception {
         Launcher.LocalLauncher localLauncher = new Launcher.LocalLauncher(StreamTaskListener.NULL);
         try {
             Assume.assumeThat("Docker working", localLauncher.launch().cmds(DockerTool.getExecutable(null, null, null, null), "ps").start().joinWithTimeout(DockerClient.CLIENT_TIMEOUT, TimeUnit.SECONDS, localLauncher.getListener()), is(0));
@@ -48,7 +53,7 @@ public class DockerTestUtil {
             Assume.assumeNoException("have Docker installed", x);
         }
         DockerClient dockerClient = new DockerClient(localLauncher, null, null);
-        Assume.assumeFalse("Docker version not < 1.3", dockerClient.version().isOlderThan(new VersionNumber("1.3")));
+        Assume.assumeFalse("Docker version not < " + minimumVersion.toString(), dockerClient.version().isOlderThan(minimumVersion));
     }
 
     private DockerTestUtil() {}


### PR DESCRIPTION
[JENKINS-44609](https://issues.jenkins-ci.org/browse/JENKINS-44609)

Instead of grabbing the image name of the first FROM statement in a Dockerfile, now will return the last one.