### PR TITLE
[FIXED JENKINS-41316] Switch 'inside' back to CMD, detect if entrypoint was badly designed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -177,6 +177,12 @@ public class WithContainerStep extends AbstractStepImpl {
             }
 
             container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ "cat");
+            final List<String> ps = dockerClient.listProcess(env, container);
+            if (!ps.contains("cat")) {
+                listener.error("The container started but didn't ran the expected command. Please double check your Entrypoint does execute the command passed as docker run argument. See https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#entrypoint for entrypoint best practices.");
+                throw new IOException("Failed to run container with CMD `cat`");
+            }
+
             DockerFingerprints.addRunFacet(dockerClient.getContainerRecord(env, container), run);
             ImageAction.add(step.image, run);
             getContext().newBodyInvoker().

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -179,8 +179,7 @@ public class WithContainerStep extends AbstractStepImpl {
             container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ "cat");
             final List<String> ps = dockerClient.listProcess(env, container);
             if (!ps.contains("cat")) {
-                listener.error("The container started but didn't ran the expected command. Please double check your Entrypoint does execute the command passed as docker run argument. See https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#entrypoint for entrypoint best practices.");
-                throw new IOException("Failed to run container with CMD `cat`");
+                listener.error("The container started but didn't run the expected command. Please double check your ENETRYPOINT does execute the command passed as docker run argument. See https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#entrypoint for entrypoint best practices.");
             }
 
             DockerFingerprints.addRunFacet(dockerClient.getContainerRecord(env, container), run);

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -179,7 +179,7 @@ public class WithContainerStep extends AbstractStepImpl {
             container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ "cat");
             final List<String> ps = dockerClient.listProcess(env, container);
             if (!ps.contains("cat")) {
-                listener.error("The container started but didn't run the expected command. Please double check your ENETRYPOINT does execute the command passed as docker run argument. See https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#entrypoint for entrypoint best practices.");
+                listener.error("The container started but didn't run the expected command. Please double check your ENTRYPOINT does execute the command passed as docker run argument. See https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#entrypoint for entrypoint best practices.");
             }
 
             DockerFingerprints.addRunFacet(dockerClient.getContainerRecord(env, container), run);

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -35,17 +35,22 @@ import org.jenkinsci.plugins.docker.commons.fingerprint.ContainerRecord;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 import java.util.List;
 import java.util.Arrays;
+import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -139,6 +144,30 @@ public class DockerClient {
         } else {
             throw new IOException(String.format("Failed to run image '%s'. Error: %s", image, result.getErr()));
         }
+    }
+
+    public List<String> listProcess(@Nonnull EnvVars launchEnv, @Nonnull String containerId) throws IOException, InterruptedException {
+        LaunchResult result = launch(launchEnv, false, "top", containerId);
+        if (result.getStatus() != 0) {
+            throw new IOException(String.format("Failed to run top '%s'. Error: %s", containerId, result.getErr()));
+        }
+        List<String> processes = new ArrayList<>();
+        try (Reader r = new StringReader(result.getOut());
+             BufferedReader in = new BufferedReader(r)) {
+            String line;
+            in.readLine(); // ps header
+            while ((line = in.readLine()) != null) {
+                final StringTokenizer stringTokenizer = new StringTokenizer(line, " ");
+                if (stringTokenizer.countTokens() < 4) {
+                    throw new IOException("Unexpected `docker top` output : "+line);
+                }
+                stringTokenizer.nextToken(); // PID
+                stringTokenizer.nextToken(); // USER
+                stringTokenizer.nextToken(); // TIME
+                processes.add(stringTokenizer.nextToken()); // COMMAND
+            }
+        }
+        return processes;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -105,10 +105,10 @@ public class DockerClient {
      * @param volumesFromContainers Mounts all volumes from the given containers.
      * @param containerEnv Environment variables to set in container.
      * @param user The <strong>uid:gid</strong> to execute the container command as. Use {@link #whoAmI()}.
-     * @param entrypoint The command to execute in the image container being run.
+     * @param command The command to execute in the image container being run.
      * @return The container ID.
      */
-    public String run(@Nonnull EnvVars launchEnv, @Nonnull String image, @CheckForNull String args, @CheckForNull String workdir, @Nonnull Map<String, String> volumes, @Nonnull Collection<String> volumesFromContainers, @Nonnull EnvVars containerEnv, @Nonnull String user, @Nonnull String entrypoint) throws IOException, InterruptedException {
+    public String run(@Nonnull EnvVars launchEnv, @Nonnull String image, @CheckForNull String args, @CheckForNull String workdir, @Nonnull Map<String, String> volumes, @Nonnull Collection<String> volumesFromContainers, @Nonnull EnvVars containerEnv, @Nonnull String user, @CheckForNull String... command) throws IOException, InterruptedException {
         ArgumentListBuilder argb = new ArgumentListBuilder();
 
         argb.add("run", "-t", "-d", "-u", user);
@@ -129,7 +129,9 @@ public class DockerClient {
             argb.add("-e");
             argb.addMasked(variable.getKey()+"="+variable.getValue());
         }
-        argb.add("--entrypoint").add(entrypoint).add(image);
+        if (command != null) {
+            argb.add(image).add(command);
+        }
 
         LaunchResult result = launch(launchEnv, false, null, argb);
         if (result.getStatus() == 0) {

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -113,7 +113,7 @@ public class DockerClient {
      * @param command The command to execute in the image container being run.
      * @return The container ID.
      */
-    public String run(@Nonnull EnvVars launchEnv, @Nonnull String image, @CheckForNull String args, @CheckForNull String workdir, @Nonnull Map<String, String> volumes, @Nonnull Collection<String> volumesFromContainers, @Nonnull EnvVars containerEnv, @Nonnull String user, @CheckForNull String... command) throws IOException, InterruptedException {
+    public String run(@Nonnull EnvVars launchEnv, @Nonnull String image, @CheckForNull String args, @CheckForNull String workdir, @Nonnull Map<String, String> volumes, @Nonnull Collection<String> volumesFromContainers, @Nonnull EnvVars containerEnv, @Nonnull String user, String... command) throws IOException, InterruptedException {
         ArgumentListBuilder argb = new ArgumentListBuilder();
 
         argb.add("run", "-t", "-d", "-u", user);

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -113,7 +113,7 @@ public class DockerClient {
      * @param command The command to execute in the image container being run.
      * @return The container ID.
      */
-    public String run(@Nonnull EnvVars launchEnv, @Nonnull String image, @CheckForNull String args, @CheckForNull String workdir, @Nonnull Map<String, String> volumes, @Nonnull Collection<String> volumesFromContainers, @Nonnull EnvVars containerEnv, @Nonnull String user, String... command) throws IOException, InterruptedException {
+    public String run(@Nonnull EnvVars launchEnv, @Nonnull String image, @CheckForNull String args, @CheckForNull String workdir, @Nonnull Map<String, String> volumes, @Nonnull Collection<String> volumesFromContainers, @Nonnull EnvVars containerEnv, @Nonnull String user, @Nonnull String... command) throws IOException, InterruptedException {
         ArgumentListBuilder argb = new ArgumentListBuilder();
 
         argb.add("run", "-t", "-d", "-u", user);
@@ -134,9 +134,7 @@ public class DockerClient {
             argb.add("-e");
             argb.addMasked(variable.getKey()+"="+variable.getValue());
         }
-        if (command != null) {
-            argb.add(image).add(command);
-        }
+        argb.add(image).add(command);
 
         LaunchResult result = launch(launchEnv, false, null, argb);
         if (result.getStatus() == 0) {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -60,7 +60,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
-import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 public class DockerDSLTest {
@@ -142,22 +141,6 @@ public class DockerDSLTest {
                 assertNotNull(facet.records.get(0).getContainerName());
                 assertEquals(Fingerprint.RangeSet.fromString("1", false), facet.getRangeSet(p));
                 assertEquals(Collections.singleton("httpd"), DockerImageExtractor.getDockerImagesUsedByJobFromAll(p));
-            }
-        });
-    }
-
-    @Issue("JENKINS-37987")
-    @Test public void entrypoint() {
-        story.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                assumeDocker();
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition(
-                        "docker.image('maven:latest').inside {\n" +
-                        "  sh 'mvn -version'\n" +
-                        "}", true));
-
-                story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             }
         });
     }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -60,6 +60,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 public class DockerDSLTest {
@@ -141,6 +142,22 @@ public class DockerDSLTest {
                 assertNotNull(facet.records.get(0).getContainerName());
                 assertEquals(Fingerprint.RangeSet.fromString("1", false), facet.getRangeSet(p));
                 assertEquals(Collections.singleton("httpd"), DockerImageExtractor.getDockerImagesUsedByJobFromAll(p));
+            }
+        });
+    }
+
+    @Issue("JENKINS-37987")
+    @Test public void entrypoint() {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                assumeDocker();
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(
+                        "docker.image('maven:latest').inside {\n" +
+                               "  sh 'mvn -version'\n" +
+                               "}", true));
+
+                story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             }
         });
     }


### PR DESCRIPTION
See discussion on https://github.com/jenkinsci/docker-workflow-plugin/pull/85