### PR TITLE
JENKINS-46105 Docker 17.05 ARG in FROM breaks docker inspect

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.workflow;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.tools.ant.types.Commandline;
+
+public final class DockerUtils {
+	private DockerUtils() {
+		// utility class
+	}
+
+	public static Map<String, String> parseBuildArgs(String commandLine) {
+		// this also accounts for quote, escapes, ...
+		Commandline parsed = new Commandline(commandLine);
+		Map<String, String> result = new HashMap<>();
+
+		String[] arguments = parsed.getArguments();
+		for (int i = 0; i < arguments.length; i++) {
+			String arg = arguments[i];
+			if (arg.equals("--build-arg")) {
+				if (arguments.length < i + 1) {
+					throw new IllegalArgumentException(
+							"Missing parameter for --build-arg: " + commandLine);
+				}
+				String keyVal = arguments[i+1];
+
+				String parts[] = keyVal.split("=", 2);
+				if (parts.length != 2) {
+					throw new IllegalArgumentException("Illegal syntax for --build-arg " + keyVal + ", need KEY=VALUE");
+				}
+				String key = parts[0];
+				String value = parts[1];
+
+				result.put(key, value);
+			}
+		}
+
+		return result;
+	}
+
+	public static SimpleEntry<String, String> splitArgs(String argString) {
+		//TODO: support complex single/double quotation marks
+		Pattern p = Pattern.compile("^['\"]?(\\w+)=(.*?)['\"]?$");
+
+		Matcher matcher = p.matcher(argString.trim());
+		if (!matcher.matches()) {
+			throw new IllegalArgumentException("Illegal --build-arg parameter syntax: " + argString);
+		}
+
+		String key = matcher.group(1);
+		String value = matcher.group(2);
+
+		return new SimpleEntry<>(key, value);
+	}
+
+
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
@@ -60,7 +60,6 @@ public final class DockerUtils {
                 result.put(key, value);
             }
         }
-
         return result;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
@@ -32,53 +32,51 @@ import java.util.regex.Pattern;
 import org.apache.tools.ant.types.Commandline;
 
 public final class DockerUtils {
-	private DockerUtils() {
-		// utility class
-	}
+    private DockerUtils() {
+        // utility class
+    }
 
-	public static Map<String, String> parseBuildArgs(String commandLine) {
-		// this also accounts for quote, escapes, ...
-		Commandline parsed = new Commandline(commandLine);
-		Map<String, String> result = new HashMap<>();
+    public static Map<String, String> parseBuildArgs(String commandLine) {
+        // this also accounts for quote, escapes, ...
+        Commandline parsed = new Commandline(commandLine);
+        Map<String, String> result = new HashMap<>();
 
-		String[] arguments = parsed.getArguments();
-		for (int i = 0; i < arguments.length; i++) {
-			String arg = arguments[i];
-			if (arg.equals("--build-arg")) {
-				if (arguments.length < i + 1) {
-					throw new IllegalArgumentException(
-							"Missing parameter for --build-arg: " + commandLine);
-				}
-				String keyVal = arguments[i+1];
+        String[] arguments = parsed.getArguments();
+        for (int i = 0; i < arguments.length; i++) {
+            String arg = arguments[i];
+            if (arg.equals("--build-arg")) {
+                if (arguments.length < i + 1) {
+                    throw new IllegalArgumentException("Missing parameter for --build-arg: " + commandLine);
+                }
+                String keyVal = arguments[i+1];
 
-				String parts[] = keyVal.split("=", 2);
-				if (parts.length != 2) {
-					throw new IllegalArgumentException("Illegal syntax for --build-arg " + keyVal + ", need KEY=VALUE");
-				}
-				String key = parts[0];
-				String value = parts[1];
+                String parts[] = keyVal.split("=", 2);
+                if (parts.length != 2) {
+                    throw new IllegalArgumentException("Illegal syntax for --build-arg " + keyVal + ", need KEY=VALUE");
+                }
+                String key = parts[0];
+                String value = parts[1];
 
-				result.put(key, value);
-			}
-		}
+                result.put(key, value);
+            }
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	public static SimpleEntry<String, String> splitArgs(String argString) {
-		//TODO: support complex single/double quotation marks
-		Pattern p = Pattern.compile("^['\"]?(\\w+)=(.*?)['\"]?$");
+    public static SimpleEntry<String, String> splitArgs(String argString) {
+        //TODO: support complex single/double quotation marks
+        Pattern p = Pattern.compile("^['\"]?(\\w+)=(.*?)['\"]?$");
 
-		Matcher matcher = p.matcher(argString.trim());
-		if (!matcher.matches()) {
-			throw new IllegalArgumentException("Illegal --build-arg parameter syntax: " + argString);
-		}
+        Matcher matcher = p.matcher(argString.trim());
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Illegal --build-arg parameter syntax: " + argString);
+        }
 
-		String key = matcher.group(1);
-		String value = matcher.group(2);
+        String key = matcher.group(1);
+        String value = matcher.group(2);
 
-		return new SimpleEntry<>(key, value);
-	}
-
+        return new SimpleEntry<>(key, value);
+    }
 
 }

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -86,8 +86,11 @@ class Docker implements Serializable {
                 }
             }
 
-            script.sh "docker build -t ${image} ${args}"
-            script.dockerFingerprintFrom dockerfile: dockerfile, image: image, toolName: script.env.DOCKER_TOOL_NAME
+            def commandLine = "docker build -t ${image} ${args}"
+            def buildArgs = DockerUtils.parseBuildArgs(commandLine)
+
+            script.sh commandLine
+            script.dockerFingerprintFrom dockerfile: dockerfile, image: image, toolName: script.env.DOCKER_TOOL_NAME, buildArgs: buildArgs
             this.image(image)
         }
     }
@@ -111,7 +114,7 @@ class Docker implements Serializable {
         public String imageName() {
             return toQualifiedImageName(id)
         }
-        
+
         public <V> V inside(String args = '', Closure<V> body) {
             docker.node {
                 def toRun = imageName()

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStepTest.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.workflow;
+
+import hudson.EnvVars;
+import hudson.Launcher.LocalLauncher;
+import hudson.model.Fingerprint;
+import hudson.util.StreamTaskListener;
+import org.jenkinsci.plugins.docker.commons.fingerprint.DockerDescendantFingerprintFacet;
+import org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints;
+import org.jenkinsci.plugins.docker.workflow.client.DockerClient;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static org.jenkinsci.plugins.docker.workflow.DockerTestUtil.assumeDocker;
+import static org.junit.Assert.assertNotNull;
+
+public class FromFingerprintStepTest {
+	@Rule
+	public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+	/**
+	 * Test quotation marks in --build-arg parameters
+	 */
+	@Test
+	public void buildWithFROMArgs()
+	throws Exception {
+
+		assertBuild("prj-simple",
+					script("--build-arg IMAGE_TO_UPDATE=hello-world:latest"));
+
+		assertBuild("prj-singlequotes-in-build-arg---aroundValue",
+					script("--build-arg IMAGE_TO_UPDATE=\\'hello-world:latest\\'"));
+
+		assertBuild("prj-dobulequotes-in-build-arg---aroundValue",
+					script("--build-arg IMAGE_TO_UPDATE=\"hello-world:latest\""));
+
+		assertBuild("prj-singlequotes-in-build-arg---aroundAll",
+					script("--build-arg \\'IMAGE_TO_UPDATE=hello-world:latest\\'"));
+
+		assertBuild("prj-doublequotes-in-build-arg---aroundAll",
+					script("--build-arg \"IMAGE_TO_UPDATE=hello-world:latest\""));
+	}
+
+	private static String script(String buildArg) {
+		String dockerfile = ""
+				+ "ARG IMAGE_TO_UPDATE\\n"
+				+ "FROM ${IMAGE_TO_UPDATE}\\n";
+		String fullBuildArgs = buildArg + " buildWithFROMArgs";
+
+		String script = "node {\n"
+				+ "  sh 'mkdir buildWithFROMArgs'\n"
+				+ "  writeFile file: 'buildWithFROMArgs/Dockerfile', text: '" + dockerfile + "'\n"
+				+ "  def built = docker.build 'from-with-arg', '" + fullBuildArgs + "'\n"
+				+ "  echo \"built ${built.id}\"\n"
+				+ "}";
+
+		return script;
+	}
+
+	private void assertBuild(final String projectName, final String piplineCode)
+	throws Exception {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate()
+			throws Throwable {
+				assumeDocker();
+
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, projectName);
+				p.setDefinition(new CpsFlowDefinition(piplineCode, true));
+				WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+				DockerClient client = new DockerClient(new LocalLauncher(StreamTaskListener.NULL), null, null);
+				String ancestorImageId = client.inspect(new EnvVars(), "hello-world", ".Id");
+				story.j.assertLogContains("built from-with-arg", b);
+				story.j.assertLogContains(ancestorImageId.replaceFirst("^sha256:", "").substring(0, 12), b);
+				Fingerprint f = DockerFingerprints.of(ancestorImageId);
+				assertNotNull(f);
+				DockerDescendantFingerprintFacet descendantFacet = f.getFacet(
+						DockerDescendantFingerprintFacet.class);
+				assertNotNull(descendantFacet);
+			}
+		});
+	}
+
+}


### PR DESCRIPTION
Fixes JENKINS-46105 Docker 17.05 ARG in FROM breaks docker inspect
https://issues.jenkins-ci.org/browse/JENKINS-46105

Introduce command line parsing using [CommandLine](http://grepcode.com/file/repo1.maven.org/maven2/org.apache.ant/ant/1.9.5/org/apache/tools/ant/types/Commandline.java) from Ant.

Then extract all --build-arg and pass it to the FromFingerprintStep to replace placeholders in the FROM image name.