### PR TITLE
[FIX JENKINS-33510] exec --workdir has been introduced in docker 17.12

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -220,8 +220,8 @@ public class WithContainerStep extends AbstractStepImpl {
             this.envHost = Util.mapToEnv(envHost);
             this.ws = ws;
             this.toolName = toolName;
-            this.hasEnv = dockerVersion.compareTo(new VersionNumber("1.13.0")) >= 0;
-            this.hasWorkdir = dockerVersion.compareTo(new VersionNumber("17.12")) >= 0;
+            this.hasEnv = dockerVersion != null && dockerVersion.compareTo(new VersionNumber("1.13.0")) >= 0;
+            this.hasWorkdir = dockerVersion != null && dockerVersion.compareTo(new VersionNumber("17.12")) >= 0;
         }
 
         @Override public Launcher decorate(final Launcher launcher, final Node node) {

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -220,8 +220,8 @@ public class WithContainerStep extends AbstractStepImpl {
             this.envHost = Util.mapToEnv(envHost);
             this.ws = ws;
             this.toolName = toolName;
-            this.hasEnv = dockerVersion.isOlderThan(new VersionNumber("1.13.0"));
-            this.hasWorkdir = !dockerVersion.isOlderThan(new VersionNumber("17.12"));
+            this.hasEnv = dockerVersion.compareTo(new VersionNumber("1.13.0")) >= 0;
+            this.hasWorkdir = dockerVersion.compareTo(new VersionNumber("17.12")) >= 0;
         }
 
         @Override public Launcher decorate(final Launcher launcher, final Node node) {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -32,6 +32,8 @@ import hudson.tools.ToolProperty;
 import java.io.File;
 import java.util.Collections;
 import java.util.logging.Level;
+
+import hudson.util.VersionNumber;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
@@ -258,9 +260,10 @@ public class WithContainerStepTest {
 
     @Issue("JENKINS-33510")
     @Test public void cd() throws Exception {
+
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
-                DockerTestUtil.assumeDocker();
+                DockerTestUtil.assumeDocker(new VersionNumber("17.12"));
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -260,7 +260,6 @@ public class WithContainerStepTest {
 
     @Issue("JENKINS-33510")
     @Test public void cd() throws Exception {
-
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 DockerTestUtil.assumeDocker(new VersionNumber("17.12"));

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -256,7 +256,6 @@ public class WithContainerStepTest {
         });
     }
 
-    @Ignore("TODO no fix yet")
     @Issue("JENKINS-33510")
     @Test public void cd() throws Exception {
         story.addStep(new Statement() {


### PR DESCRIPTION
I got https://github.com/moby/moby/issues/8917 approved and corresponding PR merged for docker 17.12, so we now have a solution for `dir()` support in docker-pipeline

Also used `--env` to support withEnvironment, to avoid the `env` command hack.