### PR TITLE
Add ARG Dockerfile values to the buildArgs collection

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
@@ -23,11 +23,8 @@
  */
 package org.jenkinsci.plugins.docker.workflow;
 
-import java.util.AbstractMap.SimpleEntry;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.tools.ant.types.Commandline;
 
@@ -62,20 +59,4 @@ public final class DockerUtils {
         }
         return result;
     }
-
-    public static SimpleEntry<String, String> splitArgs(String argString) {
-        //TODO: support complex single/double quotation marks
-        Pattern p = Pattern.compile("^['\"]?(\\w+)=(.*?)['\"]?$");
-
-        Matcher matcher = p.matcher(argString.trim());
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException("Illegal --build-arg parameter syntax: " + argString);
-        }
-
-        String key = matcher.group(1);
-        String value = matcher.group(2);
-
-        return new SimpleEntry<>(key, value);
-    }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
@@ -42,7 +42,7 @@ public final class DockerUtils {
         for (int i = 0; i < arguments.length; i++) {
             String arg = arguments[i];
             if (arg.equals("--build-arg")) {
-                if (arguments.length < i + 1) {
+                if (arguments.length <= i + 1) {
                     throw new IllegalArgumentException("Missing parameter for --build-arg: " + commandLine);
                 }
                 String keyVal = arguments[i+1];

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
@@ -33,10 +33,13 @@ public final class DockerUtils {
         // utility class
     }
 
-    public static Map<String, String> parseBuildArgs(String commandLine) {
+    public static Map<String, String> parseBuildArgs(final Dockerfile dockerfile, final String commandLine) {
         // this also accounts for quote, escapes, ...
         Commandline parsed = new Commandline(commandLine);
         Map<String, String> result = new HashMap<>();
+        if (dockerfile != null) {
+            result.putAll(dockerfile.getArgs());
+        }
 
         String[] arguments = parsed.getArguments();
         for (int i = 0; i < arguments.length; i++) {

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/Dockerfile.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/Dockerfile.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.workflow;
+
+import hudson.FilePath;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+public final class Dockerfile {
+
+    private static final String ARG = "ARG";
+    private static final String FROM = "FROM ";
+
+    private FilePath dockerfilePath;
+    private LinkedList<String> froms;
+    private Map<String,String> args;
+
+    @DataBoundConstructor public Dockerfile(FilePath dockerfilePath) throws IOException, InterruptedException {
+        this.dockerfilePath = dockerfilePath;
+        this.froms = new LinkedList<>();
+        this.args = new HashMap<>();
+        parse();
+    }
+
+    public LinkedList<String> getFroms() {
+        return froms;
+    }
+
+    public Map<String, String> getArgs() {
+        return args;
+    }
+
+    private void parse() throws IOException, InterruptedException {
+        InputStream is = dockerfilePath.read();
+        try {
+            // encoding probably irrelevant since image/tag names must be ASCII
+            BufferedReader r = new BufferedReader(new InputStreamReader(is, "ISO-8859-1"));
+            try {
+                String line;
+                while ((line = r.readLine()) != null) {
+                    line = line.trim();
+                    if (line.startsWith("#")) {
+                        continue;
+                    }
+                    if (line.startsWith(ARG)) {
+                        String[] keyVal = parseDockerfileArg(line.substring(4));
+                        args.put(keyVal[0], keyVal[1]);
+                        continue;
+                    }
+
+                    if (line.startsWith(FROM)) {
+                        froms.add(line.substring(5));
+                        continue;
+                    }
+                }
+            } finally {
+                r.close();
+            }
+        } finally {
+            is.close();
+        }
+    }
+
+    protected String[] parseDockerfileArg(String argLine) {
+        String[] keyValue = argLine.split("=", 2);
+        String key = keyValue[0];
+        String value = "";
+        if (keyValue.length > 1) {
+            value = keyValue[1];
+        }
+        return new String[]{key, value};
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -87,10 +87,9 @@ class Docker implements Serializable {
             }
 
             def commandLine = "docker build -t ${image} ${args}"
-            def buildArgs = DockerUtils.parseBuildArgs(commandLine)
 
             script.sh commandLine
-            script.dockerFingerprintFrom dockerfile: dockerfile, image: image, toolName: script.env.DOCKER_TOOL_NAME, buildArgs: buildArgs
+            script.dockerFingerprintFrom dockerfile: dockerfile, image: image, toolName: script.env.DOCKER_TOOL_NAME, commandLine: commandLine
             this.image(image)
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerUtilsTest.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.workflow;
+
+import hudson.FilePath;
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsEqual;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+public class DockerUtilsTest {
+
+    @Rule public final ExpectedException exception = ExpectedException.none();
+
+    @Test public void parseBuildArgs() throws IOException, InterruptedException {
+
+        FilePath dockerfilePath = new FilePath(new File("src/test/resources/Dockerfile-withArgs"));
+        Dockerfile dockerfile = new Dockerfile(dockerfilePath);
+
+        final String imageToUpdate = "hello-world:latest";
+        final String key = "IMAGE_TO_UPDATE";
+        final String commangLine = "docker build -t hello-world --build-arg "+key+"="+imageToUpdate;
+        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commangLine);
+
+        Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(1));
+        Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems(key));
+        Assert.assertThat(buildArgs.get(key), IsEqual.equalTo(imageToUpdate));
+    }
+
+    @Test public void parseBuildArgsWithDefaults() throws IOException, InterruptedException {
+
+        Dockerfile dockerfile = getDockerfileDefaultArgs();
+
+        final String registry = "";
+        final String key_registry = "REGISTRY_URL";
+        final String key_tag = "TAG";
+        final String commangLine = "docker build -t hello-world";
+        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commangLine);
+
+        Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(2));
+        Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems(key_registry, key_tag));
+        Assert.assertThat(buildArgs.get(key_registry), IsEqual.equalTo(registry));
+        Assert.assertThat(buildArgs.get(key_tag), IsEqual.equalTo("latest"));
+    }
+
+    @Test public void parseBuildArgsOverridingDefaults() throws IOException, InterruptedException {
+
+        Dockerfile dockerfile = getDockerfileDefaultArgs();
+
+        final String registry = "http://private.registry:5000/";
+        final String key_registry = "REGISTRY_URL";
+        final String key_tag = "TAG";
+        final String tag = "1.2.3";
+        final String commangLine = "docker build -t hello-world --build-arg "+key_tag+"="+tag+
+            " --build-arg "+key_registry+"="+registry;
+        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commangLine);
+
+        Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(2));
+        Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems(key_registry, key_tag));
+        Assert.assertThat(buildArgs.get(key_registry), IsEqual.equalTo(registry));
+        Assert.assertThat(buildArgs.get(key_tag), IsEqual.equalTo(tag));
+    }
+
+    @Test public void parseBuildArgWithKeyAndEqual() throws IOException, InterruptedException {
+        final String commangLine = "docker build -t hello-world --build-arg key=";
+
+        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(null, commangLine);
+
+        Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(1));
+        Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems("key"));
+        Assert.assertThat(buildArgs.get("key"), IsEqual.equalTo(""));
+    }
+
+    @Test public void parseInvalidBuildArg() throws IOException, InterruptedException {
+        final String commangLine = "docker build -t hello-world --build-arg";
+
+        exception.expect(IllegalArgumentException.class);
+        DockerUtils.parseBuildArgs(null, commangLine);
+    }
+
+    @Test public void parseInvalidBuildArgWithKeyOnly() throws IOException, InterruptedException {
+        final String commangLine = "docker build -t hello-world --build-arg key";
+
+        exception.expect(IllegalArgumentException.class);
+        DockerUtils.parseBuildArgs(null, commangLine);
+    }
+
+    private Dockerfile getDockerfileDefaultArgs() throws IOException, InterruptedException {
+        FilePath dockerfilePath = new FilePath(new File("src/test/resources/Dockerfile-defaultArgs"));
+        return new Dockerfile(dockerfilePath);
+    }
+}
+
+

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerfileTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerfileTest.java
@@ -45,7 +45,7 @@ public class DockerfileTest {
     @Test public void parseDockerfile() throws IOException, InterruptedException {
         Dockerfile dockerfile = new Dockerfile(dockerfilePath);
         Assert.assertThat(dockerfile.getFroms(), IsCollectionWithSize.hasSize(1));
-        Assert.assertThat(dockerfile.getFroms().getLast(), IsEqual.equalTo("${REGISTRY_URL}learn/tutorial:${TAG}"));
+        Assert.assertThat(dockerfile.getFroms().getLast(), IsEqual.equalTo("${REGISTRY_URL}hello-world:${TAG}"));
         Assert.assertThat(dockerfile.getArgs().keySet(), IsCollectionWithSize.hasSize(2));
         Assert.assertThat(dockerfile.getArgs().keySet(), IsCollectionContaining.hasItems("REGISTRY_URL", "TAG"));
     }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerfileTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerfileTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.workflow;
+
+import hudson.FilePath;
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsEqual;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+public class DockerfileTest {
+
+    private FilePath dockerfilePath;
+
+    @Before public void setUp() {
+        dockerfilePath = new FilePath(new File("src/test/resources/Dockerfile-defaultArgs"));
+    }
+
+    @Test public void parseDockerfile() throws IOException, InterruptedException {
+        Dockerfile dockerfile = new Dockerfile(dockerfilePath);
+        Assert.assertThat(dockerfile.getFroms(), IsCollectionWithSize.hasSize(1));
+        Assert.assertThat(dockerfile.getFroms().getLast(), IsEqual.equalTo("${REGISTRY_URL}learn/tutorial:${TAG}"));
+        Assert.assertThat(dockerfile.getArgs().keySet(), IsCollectionWithSize.hasSize(2));
+        Assert.assertThat(dockerfile.getArgs().keySet(), IsCollectionContaining.hasItems("REGISTRY_URL", "TAG"));
+    }
+}
+
+

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStepTest.java
@@ -44,30 +44,63 @@ import static org.junit.Assert.assertNotNull;
 public class FromFingerprintStepTest {
     @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
 
+    private static final String HELLO_WORLD_IMAGE = "hello-world";
+    private static final String BUSYBOX_IMAGE = "busybox";
+
     /**
      * Test quotation marks in --build-arg parameters
      */
     @Test public void buildWithFROMArgs() throws Exception {
-        assertBuild("prj-simple",
-            script("--build-arg IMAGE_TO_UPDATE=hello-world:latest"));
-
-        assertBuild("prj-singlequotes-in-build-arg---aroundValue",
-            script("--build-arg IMAGE_TO_UPDATE=\\'hello-world:latest\\'"));
-
-        assertBuild("prj-dobulequotes-in-build-arg---aroundValue",
-            script("--build-arg IMAGE_TO_UPDATE=\"hello-world:latest\""));
-
-        assertBuild("prj-singlequotes-in-build-arg---aroundAll",
-            script("--build-arg \\'IMAGE_TO_UPDATE=hello-world:latest\\'"));
-
-        assertBuild("prj-doublequotes-in-build-arg---aroundAll",
-            script("--build-arg \"IMAGE_TO_UPDATE=hello-world:latest\""));
-    }
-
-    private static String script(String buildArg) {
-        String dockerfile = "" + 
+        String dockerfile = "" +
             "ARG IMAGE_TO_UPDATE\\n" +
             "FROM ${IMAGE_TO_UPDATE}\\n";
+
+        assertBuild("prj-simple",
+            script(dockerfile, "--build-arg IMAGE_TO_UPDATE=hello-world:latest"), HELLO_WORLD_IMAGE);
+
+        assertBuild("prj-singlequotes-in-build-arg---aroundValue",
+            script(dockerfile, "--build-arg IMAGE_TO_UPDATE=\\'hello-world:latest\\'"), HELLO_WORLD_IMAGE);
+
+        assertBuild("prj-dobulequotes-in-build-arg---aroundValue",
+            script(dockerfile, "--build-arg IMAGE_TO_UPDATE=\"hello-world:latest\""), HELLO_WORLD_IMAGE);
+
+        assertBuild("prj-singlequotes-in-build-arg---aroundAll",
+            script(dockerfile, "--build-arg \\'IMAGE_TO_UPDATE=hello-world:latest\\'"), HELLO_WORLD_IMAGE);
+
+        assertBuild("prj-doublequotes-in-build-arg---aroundAll",
+            script(dockerfile, "--build-arg \"IMAGE_TO_UPDATE=hello-world:latest\""), HELLO_WORLD_IMAGE);
+    }
+
+    @Test public void buildWithDefaultArgsFromDockerfile() throws Exception {
+        String dockerfile = ""+
+            "ARG REGISTRY_URL\\n" +
+            "ARG TAG=latest\\n" +
+            "FROM ${REGISTRY_URL}busybox:${TAG}\\n";
+
+        assertBuild("prj-with-default-arg-from-dockerfile",
+            script(dockerfile, ""), BUSYBOX_IMAGE);
+
+        assertBuild("prj-override-empty-value",
+            script(dockerfile, "--build-arg REGISTRY_URL="), BUSYBOX_IMAGE);
+
+        assertBuild("prj-with-override-value",
+            script(dockerfile, "--build-arg TAG=1.27.1"), BUSYBOX_IMAGE+":1.27.1");
+
+        assertBuild("prj-with-override-value2",
+            script(dockerfile, "--build-arg TAG=1.26"), BUSYBOX_IMAGE+":1.26");
+    }
+
+    @Test public void buildOverridingRegistry() throws Exception {
+        String quayDockerfile = ""+
+            "ARG REGISTRY_URL\\n" +
+            "ARG TAG=latest\\n" +
+            "FROM ${REGISTRY_URL}prometheus/busybox:${TAG}\\n";
+
+        assertBuild("prj-override-registry",
+            script(quayDockerfile, "--build-arg REGISTRY_URL=\\'quay.io/\\'"), "quay.io/prometheus/busybox");
+    }
+
+    private static String script(String dockerfile, String buildArg) {
         String fullBuildArgs = buildArg + " buildWithFROMArgs";
 
         String script = "node {\n" +
@@ -80,17 +113,17 @@ public class FromFingerprintStepTest {
         return script;
     }
 
-    private void assertBuild(final String projectName, final String piplineCode) throws Exception {
+    private void assertBuild(final String projectName, final String pipelineCode, final String fromImage) throws Exception {
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
                 assumeDocker();
 
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, projectName);
-                p.setDefinition(new CpsFlowDefinition(piplineCode, true));
+                p.setDefinition(new CpsFlowDefinition(pipelineCode, true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
                 DockerClient client = new DockerClient(new LocalLauncher(StreamTaskListener.NULL), null, null);
-                String ancestorImageId = client.inspect(new EnvVars(), "hello-world", ".Id");
+                String ancestorImageId = client.inspect(new EnvVars(), fromImage, ".Id");
                 story.j.assertLogContains("built from-with-arg", b);
                 story.j.assertLogContains(ancestorImageId.replaceFirst("^sha256:", "").substring(0, 12), b);
                 Fingerprint f = DockerFingerprints.of(ancestorImageId);

--- a/src/test/resources/Dockerfile-defaultArgs
+++ b/src/test/resources/Dockerfile-defaultArgs
@@ -1,0 +1,4 @@
+# Dockerfile with FROM ARGs and default values
+ARG REGISTRY_URL
+ARG TAG=latest
+FROM ${REGISTRY_URL}hello-world:${TAG}

--- a/src/test/resources/Dockerfile-withArgs
+++ b/src/test/resources/Dockerfile-withArgs
@@ -1,0 +1,3 @@
+# Dockerfile with FROM ARG
+ARG IMAGE_TO_UPDATE
+FROM ${IMAGE_TO_UPDATE}


### PR DESCRIPTION
# Add ARG Dockerfile values to the buildArgs collection

This PR adds the ARG values from the Dockerfile instructions to the buildArgs collection added in the PR #118 

## When it's useful ?
Using this as  Dockerfile

```Dockerfile
ARG REGISTRY_URL
ARG TAG=latest
FROM ${REGISTRY_URL}hello-world:${TAG}
```

So even after the PR #118 I'm getting the `docker inspect` error in the FromFingerprintStep from the issue https://issues.jenkins-ci.org/browse/JENKINS-46105.
To get a successful build I did a workaround adding the build-args (REGISTRY_URL empty is necessary).

```
docker.build("image_name", "--build-arg REGISTRY_URL= --build-arg TAG=${version} .")
```

## Results

With this PR we are able to build the Dockerfile above without passing any --build-arg to the command.
It's reading the ARG instructions from the Dockerfile and adding to buildArgs collection as default values. When a --build-arg is informed it overrides the default value.  

To the execution bellow using the Dockerfile above the FROM Image in the FromFingerprintStep is `hello-world:latest`
```
docker.build("image_name")
```

@HonoluluHenk I hope you like my modifications