### PR TITLE
JENKINS-49005 Update Docker cgroup match pattern to catch Docker for Mac

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -57,7 +57,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Simple docker client for Pipeline.
- * 
+ *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 public class DockerClient {
@@ -73,16 +73,23 @@ public class DockerClient {
 
     // e.g. 2015-04-09T13:40:21.981801679Z
     public static final String DOCKER_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
-    
+
     /**
      * Known cgroup formats
-     * 
+     *
      * 4:cpuset:/system.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope
      * 2:cpu:/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
      * 10:cpu,cpuacct:/docker/a9f3c3932cd81c4a74cc7e0a18c3300255159512f1d000545c42895adaf68932/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
      * 3:cpu:/docker/4193df6bcf5fce75f3fc77f303b2ac06fb664adeb269b959b7ae17b3f8dcf329/14d7240da87b145e4992654c908a8631dbf179abb7f88115ea72743e1192d07d
+     *
+     * https://issues.jenkins-ci.org/browse/JENKINS-49005 and
+     * https://stackoverflow.com/questions/48258130/using-docker-pipeline-inside-a-containerized-jenkins-on-docker-for-mac/48312155#48312155
+     * Docker version 17.12.0-ce, build c97c6d6 on macOS /proc/self/cgroup
+     * 13:name=systemd:/docker-ce/docker/3abb14051eb51bab9953351c7fb94022c0826623c96ad5b40ee38de05c0b3709
+     * 12:pids:/docker-ce/docker/3abb14051eb51bab9953351c7fb94022c0826623c96ad5b40ee38de05c0b3709
+     * 11:hugetlb:/docker-ce/docker/3abb14051eb51bab9953351c7fb94022c0826623c96ad5b40ee38de05c0b3709
      */
-    public static final String CGROUP_MATCHER_PATTERN = "(?m)^\\d+:[\\w,?]+:(?:/[\\w.]+)?(?:/docker[-/])(/?(?:docker/)?(?<containerId>\\p{XDigit}{12,}))+(?:\\.scope)?$";
+    public static final String CGROUP_MATCHER_PATTERN = "(?m)^\\d+:[\\w=,]+:(?:/[\\w.]+)?(?:/docker-ce)?(/?(?:docker[-/])?(?<containerId>[0-9a-fA-F]{12,}))+(?:\\.scope)?$";
 
     private final Launcher launcher;
     private final @CheckForNull Node node;
@@ -115,7 +122,7 @@ public class DockerClient {
         if (args != null) {
             argb.addTokenized(args);
         }
-        
+
         if (workdir != null) {
             argb.add("-w", workdir);
         }
@@ -141,10 +148,10 @@ public class DockerClient {
 
     /**
      * Stop a container.
-     * 
-     * <p>                              
+     *
+     * <p>
      * Also removes ({@link #rm(EnvVars, String)}) the container.
-     * 
+     *
      * @param launchEnv Docker client launch environment.
      * @param containerId The container ID.
      */
@@ -158,7 +165,7 @@ public class DockerClient {
 
     /**
      * Remove a container.
-     * 
+     *
      * @param launchEnv Docker client launch environment.
      * @param containerId The container ID.
      */
@@ -185,7 +192,7 @@ public class DockerClient {
             return null;
         }
     }
-    
+
     /**
      * Inspect a docker image/container.
      * @param launchEnv Docker client launch environment.
@@ -196,7 +203,7 @@ public class DockerClient {
      * @throws InterruptedException Interrupted
      * @since 1.1
      */
-    public @Nonnull String inspectRequiredField(@Nonnull EnvVars launchEnv, @Nonnull String objectId, 
+    public @Nonnull String inspectRequiredField(@Nonnull EnvVars launchEnv, @Nonnull String objectId,
             @Nonnull String fieldPath) throws IOException, InterruptedException {
         final String fieldValue = inspect(launchEnv, objectId, fieldPath);
         if (fieldValue == null) {
@@ -204,7 +211,7 @@ public class DockerClient {
         }
         return fieldValue;
     }
-    
+
     private @CheckForNull Date getCreatedDate(@Nonnull EnvVars launchEnv, @Nonnull String objectId) throws IOException, InterruptedException {
         String createdString = inspect(launchEnv, objectId, "json .Created");
         if (createdString == null) {
@@ -233,7 +240,7 @@ public class DockerClient {
             return null;
         }
     }
-    
+
     private static final Pattern pattern = Pattern.compile("^(\\D+)(\\d+)\\.(\\d+)\\.(\\d+)(.*)");
     /**
      * Parse a Docker version string (e.g. "Docker version 1.5.0, build a8a31ef").
@@ -250,7 +257,7 @@ public class DockerClient {
             return new VersionNumber(String.format("%s.%s.%s", major, minor, maint));
         } else {
             return null;
-        }        
+        }
     }
 
     private LaunchResult launch(@Nonnull EnvVars launchEnv, boolean quiet, @Nonnull String... args) throws IOException, InterruptedException {
@@ -330,7 +337,7 @@ public class DockerClient {
 
         // TODO get tags and add for ContainerRecord
         return new ContainerRecord(host, containerId, image, containerName,
-                (created != null ? created.getTime() : 0L), 
+                (created != null ? created.getTime() : 0L),
                 Collections.<String,String>emptyMap());
     }
 


### PR DESCRIPTION
* Docker for Mac 17.12.0-ce now prefixes cgroup with docker-ce,
  added an optional pattern to match this.