### PR TITLE
--build-arg and its args separated by '=' breaks build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
@@ -44,10 +44,13 @@ public final class DockerUtils {
         // utility class
     }
 
-    public static Map<String, String> parseBuildArgs(String commandLineString)  {
+    public static Map<String, String> parseBuildArgs(final Dockerfile dockerfile, final String commandLineString) {
         // this also accounts for quote, escapes, ...
         Commandline commandLine = new Commandline(commandLineString);
         Map<String, String> result = new HashMap<>();
+        if (dockerfile != null) {
+            result.putAll(dockerfile.getArgs());
+        }
 
         String[] arguments = commandLine.getArguments();
         for (int i = 0; i < arguments.length; i++) {
@@ -102,24 +105,4 @@ public final class DockerUtils {
 
         return new SimpleEntry<>(key, value);
     }
-
-    /**
-     * @deprecated this implementation does not handle quotation marks properly!
-     */
-    @Deprecated
-    public static SimpleEntry<String, String> splitArgs(String argString) {
-        //TODO: support complex single/double quotation marks
-        Pattern p = Pattern.compile("^['\"]?(\\w+)=(.*?)['\"]?$");
-
-        Matcher matcher = p.matcher(argString.trim());
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException("Illegal --build-arg parameter syntax: " + argString);
-        }
-
-        String key = matcher.group(1);
-        String value = matcher.group(2);
-
-        return new SimpleEntry<>(key, value);
-    }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
@@ -28,8 +28,6 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.tools.ant.types.Commandline;
 

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
@@ -23,7 +23,9 @@
  */
 package org.jenkinsci.plugins.docker.workflow;
 
+import java.text.ParseException;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -32,37 +34,79 @@ import java.util.regex.Pattern;
 import org.apache.tools.ant.types.Commandline;
 
 public final class DockerUtils {
+
+    // marks the parameter format: --build-arg FOO=BAR
+    private static final String BUILD_ARG_SEPARATE = "--build-arg";
+    // marks the parameter format: --build-arg=FOO=BAR
+    private static final String BUILD_ARG_CONCATENATED = "--build-arg=";
+
     private DockerUtils() {
         // utility class
     }
 
-    public static Map<String, String> parseBuildArgs(String commandLine) {
+    public static Map<String, String> parseBuildArgs(String commandLineString)  {
         // this also accounts for quote, escapes, ...
-        Commandline parsed = new Commandline(commandLine);
+        Commandline commandLine = new Commandline(commandLineString);
         Map<String, String> result = new HashMap<>();
 
-        String[] arguments = parsed.getArguments();
+        String[] arguments = commandLine.getArguments();
         for (int i = 0; i < arguments.length; i++) {
             String arg = arguments[i];
-            if (arg.equals("--build-arg")) {
-                if (arguments.length < i + 1) {
-                    throw new IllegalArgumentException("Missing parameter for --build-arg: " + commandLine);
+            try {
+                if (arg.equals(BUILD_ARG_SEPARATE)) {
+                    String[] buildArgs = Arrays.copyOfRange(arguments, i, arguments.length);
+                    SimpleEntry<String, String> parsed = parseBuildArgsArray(buildArgs);
+                    result.put(parsed.getKey(), parsed.getValue());
+                } else if (arg.startsWith(BUILD_ARG_CONCATENATED)) {
+                    SimpleEntry<String, String> parsed = parseBuildArgsConcatenated(arg);
+                    result.put(parsed.getKey(), parsed.getValue());
                 }
-                String keyVal = arguments[i+1];
-
-                String parts[] = keyVal.split("=", 2);
-                if (parts.length != 2) {
-                    throw new IllegalArgumentException("Illegal syntax for --build-arg " + keyVal + ", need KEY=VALUE");
-                }
-                String key = parts[0];
-                String value = parts[1];
-
-                result.put(key, value);
+            } catch (ParseException pe) {
+                throw new IllegalArgumentException("Error parsing --build-arg: " + pe.getMessage() + ", cmdline: " + commandLineString);
             }
         }
         return result;
     }
 
+    /**
+     * Requires input: --build-arg=FOO=BAR
+     */
+    private static SimpleEntry<String, String> parseBuildArgsConcatenated(String concatenated) throws ParseException {
+        String args = concatenated.substring(BUILD_ARG_CONCATENATED.length());
+
+        SimpleEntry<String, String> result = splitArgNameValue(args);
+        return result;
+    }
+
+    /**
+     * Requires input of the format: ["--build-args", "FOO=BAR", ...]
+     */
+    private static SimpleEntry<String, String> parseBuildArgsArray(String arguments[]) throws ParseException {
+        if (arguments.length < 2) {
+			throw new ParseException("Missing parameter for --build-arg", 0);
+		}
+        String keyVal = arguments[1];
+
+        SimpleEntry<String, String> result = splitArgNameValue(keyVal);
+        return result;
+    }
+
+    private static SimpleEntry<String, String> splitArgNameValue(String nameValue) throws ParseException {
+        String parts[] = nameValue.split("=", 2);
+        if (parts.length != 2) {
+			throw new ParseException("Illegal syntax for --build-arg " + nameValue +
+                ": need further arguments with KEY=VALUE, e.g.: --build-arg FOO=Bar or --build-arg=FOO=Bar", 0);
+		}
+        String key = parts[0];
+        String value = parts[1];
+
+        return new SimpleEntry<>(key, value);
+    }
+
+    /**
+     * @deprecated this implementation does not handle quotation marks properly!
+     */
+    @Deprecated
     public static SimpleEntry<String, String> splitArgs(String argString) {
         //TODO: support complex single/double quotation marks
         Pattern p = Pattern.compile("^['\"]?(\\w+)=(.*?)['\"]?$");

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/Dockerfile.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/Dockerfile.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.workflow;
+
+import hudson.FilePath;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+public final class Dockerfile {
+
+    private static final String ARG = "ARG";
+    private static final String FROM = "FROM ";
+
+    private FilePath dockerfilePath;
+    private LinkedList<String> froms;
+    private Map<String,String> args;
+
+    @DataBoundConstructor public Dockerfile(FilePath dockerfilePath) throws IOException, InterruptedException {
+        this.dockerfilePath = dockerfilePath;
+        this.froms = new LinkedList<>();
+        this.args = new HashMap<>();
+        parse();
+    }
+
+    public LinkedList<String> getFroms() {
+        return froms;
+    }
+
+    public Map<String, String> getArgs() {
+        return args;
+    }
+
+    private void parse() throws IOException, InterruptedException {
+        InputStream is = dockerfilePath.read();
+        try {
+            // encoding probably irrelevant since image/tag names must be ASCII
+            BufferedReader r = new BufferedReader(new InputStreamReader(is, "ISO-8859-1"));
+            try {
+                String line;
+                while ((line = r.readLine()) != null) {
+                    line = line.trim();
+                    if (line.startsWith("#")) {
+                        continue;
+                    }
+                    if (line.startsWith(ARG)) {
+                        String[] keyVal = parseDockerfileArg(line.substring(4));
+                        args.put(keyVal[0], keyVal[1]);
+                        continue;
+                    }
+
+                    if (line.startsWith(FROM)) {
+                        froms.add(line.substring(5));
+                        continue;
+                    }
+                }
+            } finally {
+                r.close();
+            }
+        } finally {
+            is.close();
+        }
+    }
+
+    protected String[] parseDockerfileArg(String argLine) {
+        String[] keyValue = argLine.split("=", 2);
+        String key = keyValue[0];
+        String value = "";
+        if (keyValue.length > 1) {
+            value = keyValue[1];
+        }
+        return new String[]{key, value};
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -91,10 +91,9 @@ class Docker implements Serializable {
             }
 
             def commandLine = "docker build -t ${image} ${args}"
-            def buildArgs = DockerUtils.parseBuildArgs(commandLine)
 
             script.sh commandLine
-            script.dockerFingerprintFrom dockerfile: dockerfile, image: image, toolName: script.env.DOCKER_TOOL_NAME, buildArgs: buildArgs
+            script.dockerFingerprintFrom dockerfile: dockerfile, image: image, toolName: script.env.DOCKER_TOOL_NAME, commandLine: commandLine
             this.image(image)
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerUtilsTest.java
@@ -47,8 +47,8 @@ public class DockerUtilsTest {
 
         final String imageToUpdate = "hello-world:latest";
         final String key = "IMAGE_TO_UPDATE";
-        final String commangLine = "docker build -t hello-world --build-arg "+key+"="+imageToUpdate;
-        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commangLine);
+        final String commandLine = "docker build -t hello-world --build-arg "+key+"="+imageToUpdate;
+        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commandLine);
 
         Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(1));
         Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems(key));
@@ -62,8 +62,8 @@ public class DockerUtilsTest {
         final String registry = "";
         final String key_registry = "REGISTRY_URL";
         final String key_tag = "TAG";
-        final String commangLine = "docker build -t hello-world";
-        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commangLine);
+        final String commandLine = "docker build -t hello-world";
+        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commandLine);
 
         Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(2));
         Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems(key_registry, key_tag));
@@ -79,9 +79,9 @@ public class DockerUtilsTest {
         final String key_registry = "REGISTRY_URL";
         final String key_tag = "TAG";
         final String tag = "1.2.3";
-        final String commangLine = "docker build -t hello-world --build-arg "+key_tag+"="+tag+
+        final String commandLine = "docker build -t hello-world --build-arg "+key_tag+"="+tag+
             " --build-arg "+key_registry+"="+registry;
-        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commangLine);
+        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commandLine);
 
         Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(2));
         Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems(key_registry, key_tag));
@@ -90,9 +90,9 @@ public class DockerUtilsTest {
     }
 
     @Test public void parseBuildArgWithKeyAndEqual() throws IOException, InterruptedException {
-        final String commangLine = "docker build -t hello-world --build-arg key=";
+        final String commandLine = "docker build -t hello-world --build-arg key=";
 
-        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(null, commangLine);
+        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(null, commandLine);
 
         Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(1));
         Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems("key"));
@@ -100,17 +100,17 @@ public class DockerUtilsTest {
     }
 
     @Test public void parseInvalidBuildArg() throws IOException, InterruptedException {
-        final String commangLine = "docker build -t hello-world --build-arg";
+        final String commandLine = "docker build -t hello-world --build-arg";
 
         exception.expect(IllegalArgumentException.class);
-        DockerUtils.parseBuildArgs(null, commangLine);
+        DockerUtils.parseBuildArgs(null, commandLine);
     }
 
     @Test public void parseInvalidBuildArgWithKeyOnly() throws IOException, InterruptedException {
-        final String commangLine = "docker build -t hello-world --build-arg key";
+        final String commandLine = "docker build -t hello-world --build-arg key";
 
         exception.expect(IllegalArgumentException.class);
-        DockerUtils.parseBuildArgs(null, commangLine);
+        DockerUtils.parseBuildArgs(null, commandLine);
     }
 
     private Dockerfile getDockerfileDefaultArgs() throws IOException, InterruptedException {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerUtilsTest.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.workflow;
+
+import hudson.FilePath;
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsEqual;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+public class DockerUtilsTest {
+
+    @Rule public final ExpectedException exception = ExpectedException.none();
+
+    @Test public void parseBuildArgs() throws IOException, InterruptedException {
+
+        FilePath dockerfilePath = new FilePath(new File("src/test/resources/Dockerfile-withArgs"));
+        Dockerfile dockerfile = new Dockerfile(dockerfilePath);
+
+        final String imageToUpdate = "hello-world:latest";
+        final String key = "IMAGE_TO_UPDATE";
+        final String commangLine = "docker build -t hello-world --build-arg "+key+"="+imageToUpdate;
+        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commangLine);
+
+        Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(1));
+        Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems(key));
+        Assert.assertThat(buildArgs.get(key), IsEqual.equalTo(imageToUpdate));
+    }
+
+    @Test public void parseBuildArgsWithDefaults() throws IOException, InterruptedException {
+
+        Dockerfile dockerfile = getDockerfileDefaultArgs();
+
+        final String registry = "";
+        final String key_registry = "REGISTRY_URL";
+        final String key_tag = "TAG";
+        final String commangLine = "docker build -t hello-world";
+        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commangLine);
+
+        Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(2));
+        Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems(key_registry, key_tag));
+        Assert.assertThat(buildArgs.get(key_registry), IsEqual.equalTo(registry));
+        Assert.assertThat(buildArgs.get(key_tag), IsEqual.equalTo("latest"));
+    }
+
+    @Test public void parseBuildArgsOverridingDefaults() throws IOException, InterruptedException {
+
+        Dockerfile dockerfile = getDockerfileDefaultArgs();
+
+        final String registry = "http://private.registry:5000/";
+        final String key_registry = "REGISTRY_URL";
+        final String key_tag = "TAG";
+        final String tag = "1.2.3";
+        final String commangLine = "docker build -t hello-world --build-arg "+key_tag+"="+tag+
+            " --build-arg "+key_registry+"="+registry;
+        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commangLine);
+
+        Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(2));
+        Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems(key_registry, key_tag));
+        Assert.assertThat(buildArgs.get(key_registry), IsEqual.equalTo(registry));
+        Assert.assertThat(buildArgs.get(key_tag), IsEqual.equalTo(tag));
+    }
+
+    @Test public void parseBuildArgWithKeyAndEqual() throws IOException, InterruptedException {
+        final String commangLine = "docker build -t hello-world --build-arg key=";
+
+        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(null, commangLine);
+
+        Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(1));
+        Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems("key"));
+        Assert.assertThat(buildArgs.get("key"), IsEqual.equalTo(""));
+    }
+
+    @Test public void parseInvalidBuildArg() throws IOException, InterruptedException {
+        final String commangLine = "docker build -t hello-world --build-arg";
+
+        exception.expect(IllegalArgumentException.class);
+        DockerUtils.parseBuildArgs(null, commangLine);
+    }
+
+    @Test public void parseInvalidBuildArgWithKeyOnly() throws IOException, InterruptedException {
+        final String commangLine = "docker build -t hello-world --build-arg key";
+
+        exception.expect(IllegalArgumentException.class);
+        DockerUtils.parseBuildArgs(null, commangLine);
+    }
+
+    private Dockerfile getDockerfileDefaultArgs() throws IOException, InterruptedException {
+        FilePath dockerfilePath = new FilePath(new File("src/test/resources/Dockerfile-defaultArgs"));
+        return new Dockerfile(dockerfilePath);
+    }
+}
+
+

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerUtilsTest.java
@@ -23,99 +23,184 @@
  */
 package org.jenkinsci.plugins.docker.workflow;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import hudson.FilePath;
-import org.hamcrest.collection.IsCollectionWithSize;
-import org.hamcrest.core.IsCollectionContaining;
-import org.hamcrest.core.IsEqual;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
+import static com.google.common.collect.ImmutableMultimap.of;
+import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.isIn;
+import static org.junit.Assert.assertThat;
 
+@RunWith(Parameterized.class)
 public class DockerUtilsTest {
 
-    @Rule public final ExpectedException exception = ExpectedException.none();
-
-    @Test public void parseBuildArgs() throws IOException, InterruptedException {
-
-        FilePath dockerfilePath = new FilePath(new File("src/test/resources/Dockerfile-withArgs"));
-        Dockerfile dockerfile = new Dockerfile(dockerfilePath);
-
-        final String imageToUpdate = "hello-world:latest";
-        final String key = "IMAGE_TO_UPDATE";
-        final String commandLine = "docker build -t hello-world --build-arg "+key+"="+imageToUpdate;
-        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commandLine);
-
-        Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(1));
-        Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems(key));
-        Assert.assertThat(buildArgs.get(key), IsEqual.equalTo(imageToUpdate));
+    // parameters trigger the possible valid(!) combinations of:
+    //
+    // Param0: should --build-arg and Param-Name be separated by '=' or by ' '?
+    // examples:
+    // --build-arg FOO=BAR
+    // --build-arg=FOO=BAR
+    //
+    // Param1: should an empty parameter (i.e.: key without value) have the '=' suffix?
+    // examples
+    // --build-arg FOO
+    // --build-arg FOO=
+    @Parameters(name = "{0}/{1}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { '=', true },
+            { '=', false },
+            { ' ', true },
+            { ' ', false },
+        });
     }
 
-    @Test public void parseBuildArgsWithDefaults() throws IOException, InterruptedException {
+    @Parameter()
+    public char buildArgsSeparator;
 
-        Dockerfile dockerfile = getDockerfileDefaultArgs();
+    @Parameter(1)
+    public boolean argValuePrefix;
 
-        final String registry = "";
-        final String key_registry = "REGISTRY_URL";
-        final String key_tag = "TAG";
-        final String commandLine = "docker build -t hello-world";
-        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commandLine);
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
-        Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(2));
-        Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems(key_registry, key_tag));
-        Assert.assertThat(buildArgs.get(key_registry), IsEqual.equalTo(registry));
-        Assert.assertThat(buildArgs.get(key_tag), IsEqual.equalTo("latest"));
+    // given
+    private Dockerfile dockerfile = null;
+    private Multimap<String, String> buildArgs = null;
+    private String commandLine = null;
+
+    // when
+    private Map<String, String> parsedArgs = null;
+
+    @Test
+    public void parseBuildArgs() {
+        givenDockerfile("src/test/resources/Dockerfile-withArgs");
+        givenBuildArgs(of("IMAGE_TO_UPDATE", "hello-world:latest"));
+        givenCommandLine(withBuildArgsBySeparator());
+
+        whenCommandLineIsParsed();
+
+        thenParsedArgsContainExactly(buildArgs);
     }
 
-    @Test public void parseBuildArgsOverridingDefaults() throws IOException, InterruptedException {
+    @Test
+    public void parseBuildArgsWithDefaults() {
+        givenDockerfileDefaultArgs();
+        givenBuildArgs(of());
+        givenCommandLine(emptyList());
 
-        Dockerfile dockerfile = getDockerfileDefaultArgs();
+        whenCommandLineIsParsed();
 
-        final String registry = "http://private.registry:5000/";
-        final String key_registry = "REGISTRY_URL";
-        final String key_tag = "TAG";
-        final String tag = "1.2.3";
-        final String commandLine = "docker build -t hello-world --build-arg "+key_tag+"="+tag+
-            " --build-arg "+key_registry+"="+registry;
-        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, commandLine);
-
-        Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(2));
-        Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems(key_registry, key_tag));
-        Assert.assertThat(buildArgs.get(key_registry), IsEqual.equalTo(registry));
-        Assert.assertThat(buildArgs.get(key_tag), IsEqual.equalTo(tag));
+        // these are the defaults defined in the Dockerfile
+        thenParsedArgsContainExactly
+            (of("REGISTRY_URL", "",
+                "TAG", "latest"));
     }
 
-    @Test public void parseBuildArgWithKeyAndEqual() throws IOException, InterruptedException {
-        final String commandLine = "docker build -t hello-world --build-arg key=";
+    @Test
+    public void parseBuildArgsOverridingDefaults() {
+        givenDockerfileDefaultArgs();
+        givenBuildArgs(
+            of("TAG", "1.2.3",
+                "REGISTRY_URL", "http://private.registry:5000/"));
+        givenCommandLine(withBuildArgsBySeparator());
 
-        Map<String, String> buildArgs = DockerUtils.parseBuildArgs(null, commandLine);
+        whenCommandLineIsParsed();
 
-        Assert.assertThat(buildArgs.keySet(), IsCollectionWithSize.hasSize(1));
-        Assert.assertThat(buildArgs.keySet(), IsCollectionContaining.hasItems("key"));
-        Assert.assertThat(buildArgs.get("key"), IsEqual.equalTo(""));
+        thenParsedArgsContainExactly(buildArgs);
     }
 
-    @Test public void parseInvalidBuildArg() throws IOException, InterruptedException {
+    @Test
+    public void parseBuildArgWithKeyAndEqual() {
+        givenNoDockerfile();
+        givenBuildArgs(of("key", ""));
+        givenCommandLine(withBuildArgsBySeparator());
+
+        whenCommandLineIsParsed();
+
+        thenParsedArgsContainExactly(of("key", ""));
+    }
+
+    @Test
+    public void parseInvalidBuildArg() {
         final String commandLine = "docker build -t hello-world --build-arg";
 
         exception.expect(IllegalArgumentException.class);
         DockerUtils.parseBuildArgs(null, commandLine);
     }
 
-    @Test public void parseInvalidBuildArgWithKeyOnly() throws IOException, InterruptedException {
-        final String commandLine = "docker build -t hello-world --build-arg key";
-
-        exception.expect(IllegalArgumentException.class);
-        DockerUtils.parseBuildArgs(null, commandLine);
+    private void givenNoDockerfile() {
+        dockerfile = null;
     }
 
-    private Dockerfile getDockerfileDefaultArgs() throws IOException, InterruptedException {
-        FilePath dockerfilePath = new FilePath(new File("src/test/resources/Dockerfile-defaultArgs"));
-        return new Dockerfile(dockerfilePath);
+    private void givenDockerfile(String dockerFilePath) {
+        FilePath dockerfilePath = new FilePath(new File(dockerFilePath));
+        try {
+            dockerfile = new Dockerfile(dockerfilePath);
+        } catch (Exception e) {
+            throw new IllegalStateException("Dockerfile not found: " + dockerFilePath);
+        }
+    }
+
+    private void givenDockerfileDefaultArgs() {
+        givenDockerfile("src/test/resources/Dockerfile-defaultArgs");
+    }
+
+    private void givenBuildArgs(Multimap<String, String> args) {
+        buildArgs = ImmutableMultimap.copyOf(args);
+    }
+
+    private List<String> withBuildArgsBySeparator() {
+        return buildArgs.entries().stream()
+            .map(param -> createBuildArgParam(buildArgsSeparator, argValuePrefix, param))
+            .collect(Collectors.toList());
+    }
+
+    private void givenCommandLine(List<String> buildArgs) {
+        StringBuilder cmd = new StringBuilder("docker build -t hello-world");
+        for (String arg : buildArgs) {
+            cmd.append(" ").append(arg);
+        }
+        this.commandLine = cmd.toString();
+    }
+
+    private void whenCommandLineIsParsed() {
+        parsedArgs = DockerUtils.parseBuildArgs(dockerfile, commandLine);
+    }
+
+    private void thenParsedArgsContainExactly(Multimap<String, String> expected) {
+        assertThat(parsedArgs.entrySet(), everyItem(isIn(expected.entries())));
+        assertThat(expected.entries(), everyItem(isIn(parsedArgs.entrySet())));
+    }
+
+    private String createBuildArgParam(char buildArgSeparator, boolean emptyValuePrefixEquals,
+        Entry<String, String> param) {
+        String result = " --build-arg" + buildArgSeparator + joinValue(emptyValuePrefixEquals, param);
+        return result;
+    }
+
+    private String joinValue(boolean emptyValuePrefixEquals, Entry<String, String> param) {
+        if (isNotBlank(param.getValue())) {
+            return param.getKey() + "=" + param.getValue();
+        }
+        return param.getKey() + (emptyValuePrefixEquals ? "=" : "");
     }
 }
 

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerfileTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerfileTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.workflow;
+
+import hudson.FilePath;
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsEqual;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+public class DockerfileTest {
+
+    private FilePath dockerfilePath;
+
+    @Before public void setUp() {
+        dockerfilePath = new FilePath(new File("src/test/resources/Dockerfile-defaultArgs"));
+    }
+
+    @Test public void parseDockerfile() throws IOException, InterruptedException {
+        Dockerfile dockerfile = new Dockerfile(dockerfilePath);
+        Assert.assertThat(dockerfile.getFroms(), IsCollectionWithSize.hasSize(1));
+        Assert.assertThat(dockerfile.getFroms().getLast(), IsEqual.equalTo("${REGISTRY_URL}hello-world:${TAG}"));
+        Assert.assertThat(dockerfile.getArgs().keySet(), IsCollectionWithSize.hasSize(2));
+        Assert.assertThat(dockerfile.getArgs().keySet(), IsCollectionContaining.hasItems("REGISTRY_URL", "TAG"));
+    }
+}
+
+

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStepTest.java
@@ -47,47 +47,6 @@ public class FromFingerprintStepTest {
     private static final String HELLO_WORLD_IMAGE = "hello-world";
     private static final String BUSYBOX_IMAGE = "busybox";
 
-    /*
-        @Test public void buildWithFROMArgs() throws Exception {
-        assertBuild("prj-simple",
-            script("--build-arg IMAGE_TO_UPDATE=hello-world:latest"));
-
-        assertBuild("prj-singlequotes-in-build-arg---aroundValue",
-            script("--build-arg IMAGE_TO_UPDATE=\\'hello-world:latest\\'"));
-
-        assertBuild("prj-dobulequotes-in-build-arg---aroundValue",
-            script("--build-arg IMAGE_TO_UPDATE=\"hello-world:latest\""));
-
-        assertBuild("prj-singlequotes-in-build-arg---aroundAllArgs",
-            script("--build-arg \\'IMAGE_TO_UPDATE=hello-world:latest\\'"));
-
-        assertBuild("prj-doublequotes-in-build-arg---aroundAllArgs",
-            script("--build-arg \"IMAGE_TO_UPDATE=hello-world:latest\""));
-
-        // and again with equals after --build-arg
-        assertBuild("prj-equals-simple",
-            script("--build-arg=IMAGE_TO_UPDATE=hello-world:latest"));
-
-        assertBuild("prj-equals-singlequotes-in-build-arg---aroundValue",
-            script("--build-arg=IMAGE_TO_UPDATE=\\'hello-world:latest\\'"));
-
-        assertBuild("prj-equals-dobulequotes-in-build-arg---aroundValue",
-            script("--build-arg=IMAGE_TO_UPDATE=\"hello-world:latest\""));
-
-        assertBuild("prj-equals-singlequotes-in-build-arg---aroundAllArgs",
-            script("--build-arg=\\'IMAGE_TO_UPDATE=hello-world:latest\\'"));
-
-        assertBuild("prj-equals-doublequotes-in-build-arg---aroundAllArgs",
-            script("--build-arg=\"IMAGE_TO_UPDATE=hello-world:latest\""));
-
-        // quotes around all of the --build-arg= stuff
-        assertBuild("prj-equals-singlequotes-in-build-arg---aroundAll",
-            script("\\'--build-arg=IMAGE_TO_UPDATE=hello-world:latest\\'"));
-
-        assertBuild("prj-equals-doublequotes-in-build-arg---aroundAll",
-            script("\"--build-arg=IMAGE_TO_UPDATE=hello-world:latest\""));
-    }
-     */
     /**
      * Test quotation marks in --build-arg parameters
      */
@@ -105,11 +64,34 @@ public class FromFingerprintStepTest {
         assertBuild("prj-dobulequotes-in-build-arg---aroundValue",
             script(dockerfile, "--build-arg IMAGE_TO_UPDATE=\"hello-world:latest\""), HELLO_WORLD_IMAGE);
 
-        assertBuild("prj-singlequotes-in-build-arg---aroundAll",
+        assertBuild("prj-singlequotes-in-build-arg---aroundAllArgs",
             script(dockerfile, "--build-arg \\'IMAGE_TO_UPDATE=hello-world:latest\\'"), HELLO_WORLD_IMAGE);
 
-        assertBuild("prj-doublequotes-in-build-arg---aroundAll",
+        assertBuild("prj-doublequotes-in-build-arg---aroundAllArgs",
             script(dockerfile, "--build-arg \"IMAGE_TO_UPDATE=hello-world:latest\""), HELLO_WORLD_IMAGE);
+
+        // and again with equals after --build-arg
+        assertBuild("prj-equals-simple",
+            script(dockerfile, "--build-arg=IMAGE_TO_UPDATE=hello-world:latest"), HELLO_WORLD_IMAGE);
+
+        assertBuild("prj-equals-singlequotes-in-build-arg---aroundValue",
+            script(dockerfile, "--build-arg=IMAGE_TO_UPDATE=\\'hello-world:latest\\'"), HELLO_WORLD_IMAGE);
+
+        assertBuild("prj-equals-dobulequotes-in-build-arg---aroundValue",
+            script(dockerfile, "--build-arg=IMAGE_TO_UPDATE=\"hello-world:latest\""), HELLO_WORLD_IMAGE);
+
+        assertBuild("prj-equals-singlequotes-in-build-arg---aroundAllArgs",
+            script(dockerfile, "--build-arg=\\'IMAGE_TO_UPDATE=hello-world:latest\\'"), HELLO_WORLD_IMAGE);
+
+        assertBuild("prj-equals-doublequotes-in-build-arg---aroundAllArgs",
+            script(dockerfile, "--build-arg=\"IMAGE_TO_UPDATE=hello-world:latest\""), HELLO_WORLD_IMAGE);
+
+        // quotes around all of the --build-arg= stuff
+        assertBuild("prj-equals-singlequotes-in-build-arg---aroundAll",
+            script(dockerfile, "\\'--build-arg=IMAGE_TO_UPDATE=hello-world:latest\\'"), HELLO_WORLD_IMAGE);
+
+        assertBuild("prj-equals-doublequotes-in-build-arg---aroundAll",
+            script(dockerfile, "\"--build-arg=IMAGE_TO_UPDATE=hello-world:latest\""), HELLO_WORLD_IMAGE);
     }
 
     @Test public void buildWithDefaultArgsFromDockerfile() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStepTest.java
@@ -57,16 +57,39 @@ public class FromFingerprintStepTest {
         assertBuild("prj-dobulequotes-in-build-arg---aroundValue",
             script("--build-arg IMAGE_TO_UPDATE=\"hello-world:latest\""));
 
-        assertBuild("prj-singlequotes-in-build-arg---aroundAll",
+        assertBuild("prj-singlequotes-in-build-arg---aroundAllArgs",
             script("--build-arg \\'IMAGE_TO_UPDATE=hello-world:latest\\'"));
 
-        assertBuild("prj-doublequotes-in-build-arg---aroundAll",
+        assertBuild("prj-doublequotes-in-build-arg---aroundAllArgs",
             script("--build-arg \"IMAGE_TO_UPDATE=hello-world:latest\""));
+
+        // and again with equals after --build-arg
+        assertBuild("prj-equals-simple",
+            script("--build-arg=IMAGE_TO_UPDATE=hello-world:latest"));
+
+        assertBuild("prj-equals-singlequotes-in-build-arg---aroundValue",
+            script("--build-arg=IMAGE_TO_UPDATE=\\'hello-world:latest\\'"));
+
+        assertBuild("prj-equals-dobulequotes-in-build-arg---aroundValue",
+            script("--build-arg=IMAGE_TO_UPDATE=\"hello-world:latest\""));
+
+        assertBuild("prj-equals-singlequotes-in-build-arg---aroundAllArgs",
+            script("--build-arg=\\'IMAGE_TO_UPDATE=hello-world:latest\\'"));
+
+        assertBuild("prj-equals-doublequotes-in-build-arg---aroundAllArgs",
+            script("--build-arg=\"IMAGE_TO_UPDATE=hello-world:latest\""));
+
+        // quotes around all of the --build-arg= stuff
+        assertBuild("prj-equals-singlequotes-in-build-arg---aroundAll",
+            script("\\'--build-arg=IMAGE_TO_UPDATE=hello-world:latest\\'"));
+
+        assertBuild("prj-equals-doublequotes-in-build-arg---aroundAll",
+            script("\"--build-arg=IMAGE_TO_UPDATE=hello-world:latest\""));
     }
 
     private static String script(String buildArg) {
         String dockerfile = "" + 
-            "ARG IMAGE_TO_UPDATE\\n" +
+            "ARG IMAGE_TO_UPDATE=hello-world:latest\\n" +
             "FROM ${IMAGE_TO_UPDATE}\\n";
         String fullBuildArgs = buildArg + " buildWithFROMArgs";
 

--- a/src/test/resources/Dockerfile-defaultArgs
+++ b/src/test/resources/Dockerfile-defaultArgs
@@ -1,0 +1,4 @@
+# Dockerfile with FROM ARGs and default values
+ARG REGISTRY_URL
+ARG TAG=latest
+FROM ${REGISTRY_URL}hello-world:${TAG}

--- a/src/test/resources/Dockerfile-withArgs
+++ b/src/test/resources/Dockerfile-withArgs
@@ -1,0 +1,3 @@
+# Dockerfile with FROM ARG
+ARG IMAGE_TO_UPDATE
+FROM ${IMAGE_TO_UPDATE}


### PR DESCRIPTION
See comment by Peter Grayson in JENKINS-46105.

This fix extends PR #118.

Please *strongly* consider merging #126 beforehand since that PR has some important fixes regarding --build-arg (I'd be glad to resolve merge conflicts)