### PR TITLE
[JENKINS-51395] Syntax problems in withDockerRegistry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <java.level>8</java.level>
         <workflow-step-api-plugin.version>2.9</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>2.12</workflow-support-plugin.version>
+        <workflow-cps-plugin.version>2.25</workflow-cps-plugin.version>
     </properties>
     <repositories>
         <repository>
@@ -55,7 +56,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.25</version>
+            <version>${workflow-cps-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -98,6 +99,13 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <version>${workflow-support-plugin.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>${workflow-cps-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
[JENKINS-51395](https://issues.jenkins-ci.org/browse/JENKINS-51395): #133 broke scripts using the notation

```groovy
withDockerRegistry([…])
```

which is unfortunately what **Pipeline Syntax** suggests if you have no `toolName`. (@abayer patched both `DSL` and `SnippetizerTest` in https://github.com/jenkinsci/workflow-cps-plugin/pull/49, but the behaviors do not seem to actually match in the case that there is one required structure parameter _and_ an optional parameter.)

@oleg-nenashev had written some test coverage for the configuration form of this step long ago, but it did not actually attempt to _run_ the step, and the DSL `docker.withRegistry` always calls the more verbose form.

It is no longer possible to compatibly remove the new `toolName` parameter, and anyway we need it, so my current plan is to try to inline the `DockerRegistryEndpoint` parameter, assuming that is even possible.