### PR TITLE
[JENKINS-48437] Use the new API passing the Run to retrieve the token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-commons</artifactId>
-            <version>1.13</version>
+            <version>1.14-rc165.6f6d770d4e88</version> <!-- TODO https://github.com/jenkinsci/docker-commons-plugin/pull/68 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-commons</artifactId>
-            <version>1.14-rc165.6f6d770d4e88</version> <!-- TODO https://github.com/jenkinsci/docker-commons-plugin/pull/68 -->
+            <version>1.14-rc171.bc6d2dea6b49</version> <!-- TODO https://github.com/jenkinsci/docker-commons-plugin/pull/68 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/RegistryEndpointStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/RegistryEndpointStep.java
@@ -29,8 +29,8 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
-import hudson.model.Job;
 import hudson.model.Node;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.Collections;
@@ -77,15 +77,15 @@ public class RegistryEndpointStep extends AbstractStepImpl {
         private static final long serialVersionUID = 1;
 
         @Inject(optional=true) private transient RegistryEndpointStep step;
-        @StepContextParameter private transient Job<?,?> job;
         @StepContextParameter private transient FilePath workspace;
         @StepContextParameter private transient Launcher launcher;
         @StepContextParameter private transient TaskListener listener;
         @StepContextParameter private transient Node node;
         @StepContextParameter private transient EnvVars envVars;
+        @StepContextParameter private transient Run run;
 
         @Override protected KeyMaterialFactory newKeyMaterialFactory() throws IOException, InterruptedException {
-            return step.registry.newKeyMaterialFactory(job, workspace, launcher, envVars, listener, DockerTool.getExecutable(step.toolName, node, listener, envVars));
+            return step.registry.newKeyMaterialFactory(run, workspace, launcher, envVars, listener, DockerTool.getExecutable(step.toolName, node, listener, envVars));
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/ServerEndpointStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/ServerEndpointStep.java
@@ -26,9 +26,10 @@ package org.jenkinsci.plugins.docker.workflow;
 import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.model.Job;
 import java.io.IOException;
 import javax.annotation.Nonnull;
+
+import hudson.model.Run;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
 import org.jenkinsci.plugins.docker.commons.credentials.KeyMaterialFactory;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
@@ -54,11 +55,11 @@ public class ServerEndpointStep extends AbstractStepImpl {
         private static final long serialVersionUID = 1;
 
         @Inject(optional=true) private transient ServerEndpointStep step;
-        @StepContextParameter private transient Job<?,?> job;
+        @StepContextParameter private transient Run run;
         @StepContextParameter private transient FilePath workspace;
 
         @Override protected KeyMaterialFactory newKeyMaterialFactory() throws IOException, InterruptedException {
-            return step.server.newKeyMaterialFactory(job, workspace.getChannel());
+            return step.server.newKeyMaterialFactory(run, workspace.getChannel());
         }
 
     }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/RegistryEndpointStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/RegistryEndpointStepTest.java
@@ -110,22 +110,20 @@ public class RegistryEndpointStepTest {
     @Test
     public void stepExecutionWithCredentials() throws Exception {
         assumeNotWindows();
-        
+
         IdCredentials registryCredentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "registryCreds", null, "me", "pass");
         CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), registryCredentials);
 
         WorkflowJob p = r.createProject(WorkflowJob.class, "prj");
         p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                        "  mockDockerLoginWithEcho {\n" +
+                        "  mockDockerWithEcho {\n" +
                         "    withDockerRegistry(url: 'https://my-reg:1234', credentialsId: 'registryCreds') {\n" +
-                        "       echo 'config would be set up to connect to https://my-reg:1234'\n" +
                         "    }\n" +
                         "  }\n" +
                         "}", true));
         WorkflowRun b = r.buildAndAssertSuccess(p);
         r.assertLogContains("docker login -u me -p pass https://my-reg:1234", r.assertBuildStatusSuccess(r.waitForCompletion(b)));
-        r.assertLogContains("config would be set up to connect to https://my-reg:1234", b);
     }
 
     @Test
@@ -145,9 +143,8 @@ public class RegistryEndpointStepTest {
         WorkflowJob p = r.createProject(WorkflowJob.class, "prj");
         p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                        "  mockDockerLoginWithEcho {\n" +
+                        "  mockDockerWithEcho {\n" +
                         "    withDockerRegistry(url: 'https://my-reg:1234', credentialsId: 'registryCreds') {\n" +
-                        "       echo 'config would be set up to connect to https://my-reg:1234'\n" +
                         "    }\n" +
                         "  }\n" +
                         "}", true));
@@ -160,7 +157,6 @@ public class RegistryEndpointStepTest {
             b = r.buildAndAssertSuccess(p);
         }
         r.assertLogContains("docker login -u me -p pass https://my-reg:1234", b);
-        r.assertLogContains("config would be set up to connect to https://my-reg:1234", b);
     }
 
     public static class MockLauncherWithEchoStep extends Step {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/RegistryEndpointStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/RegistryEndpointStepTest.java
@@ -46,6 +46,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.*;
 
+import static org.jenkinsci.plugins.docker.workflow.DockerTestUtil.assumeNotWindows;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -108,6 +109,8 @@ public class RegistryEndpointStepTest {
 
     @Test
     public void stepExecutionWithCredentials() throws Exception {
+        assumeNotWindows();
+        
         IdCredentials registryCredentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "registryCreds", null, "me", "pass");
         CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), registryCredentials);
 
@@ -127,6 +130,7 @@ public class RegistryEndpointStepTest {
 
     @Test
     public void stepExecutionWithCredentialsAndQueueItemAuthenticator() throws Exception {
+        assumeNotWindows();
 
         r.getInstance().setSecurityRealm(r.createDummySecurityRealm());
         MockAuthorizationStrategy auth = new MockAuthorizationStrategy()

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/RegistryEndpointStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/RegistryEndpointStepTest.java
@@ -117,7 +117,7 @@ public class RegistryEndpointStepTest {
         WorkflowJob p = r.createProject(WorkflowJob.class, "prj");
         p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                        "  mockDockerWithEcho {\n" +
+                        "  mockDockerLoginWithEcho {\n" +
                         "    withDockerRegistry(url: 'https://my-reg:1234', credentialsId: 'registryCreds') {\n" +
                         "    }\n" +
                         "  }\n" +
@@ -143,7 +143,7 @@ public class RegistryEndpointStepTest {
         WorkflowJob p = r.createProject(WorkflowJob.class, "prj");
         p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                        "  mockDockerWithEcho {\n" +
+                        "  mockDockerLoginWithEcho {\n" +
                         "    withDockerRegistry(url: 'https://my-reg:1234', credentialsId: 'registryCreds') {\n" +
                         "    }\n" +
                         "  }\n" +

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/ServerEndpointStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/ServerEndpointStepTest.java
@@ -114,6 +114,7 @@ public class ServerEndpointStepTest {
     @Test public void stepExecutionWithCredentials() {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
+                assumeNotWindows();
                 IdCredentials serverCredentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "serverCreds", null, "clientKey", "clientCertificate", "serverCaCertificate");
                 CredentialsProvider.lookupStores(story.j.jenkins).iterator().next().addCredentials(Domain.global(), serverCredentials);
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
@@ -133,6 +134,7 @@ public class ServerEndpointStepTest {
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
+                assumeNotWindows();
                 story.j.getInstance().setSecurityRealm(story.j.createDummySecurityRealm());
                 MockAuthorizationStrategy auth = new MockAuthorizationStrategy()
                         .grant(Jenkins.READ).everywhere().to("alice")

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/ServerEndpointStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/ServerEndpointStepTest.java
@@ -122,10 +122,14 @@ public class ServerEndpointStepTest {
                         "node {\n" +
                                 "  withDockerServer(server: [uri: 'tcp://host:1234', credentialsId: 'serverCreds']) {\n" +
                                 "    sh 'echo would be connecting to $DOCKER_HOST'\n" +
+                                "    sh 'echo DOCKER_TLS_VERIFY=$DOCKER_TLS_VERIFY'\n" +
+                                "    sh 'echo DOCKER_CERT_PATH=$DOCKER_CERT_PATH is not empty'\n" +
                                 "  }\n" +
                                 "}", true));
                 WorkflowRun b = story.j.buildAndAssertSuccess(p);
                 story.j.assertLogContains("would be connecting to tcp://host:1234", b);
+                story.j.assertLogContains("DOCKER_TLS_VERIFY=1", b);
+                story.j.assertLogNotContains("DOCKER_CERT_PATH= is not empty", b);
             }
         });
     }
@@ -150,6 +154,8 @@ public class ServerEndpointStepTest {
                         "node {\n" +
                                 "  withDockerServer(server: [uri: 'tcp://host:1234', credentialsId: 'serverCreds']) {\n" +
                                 "    sh 'echo would be connecting to $DOCKER_HOST'\n" +
+                                "    sh 'echo DOCKER_TLS_VERIFY=$DOCKER_TLS_VERIFY'\n" +
+                                "    sh 'echo DOCKER_CERT_PATH=$DOCKER_CERT_PATH is not empty'\n" +
                                 "  }\n" +
                                 "}", true));
 
@@ -161,6 +167,8 @@ public class ServerEndpointStepTest {
                     b = story.j.buildAndAssertSuccess(p);
                 }
                 story.j.assertLogContains("would be connecting to tcp://host:1234", b);
+                story.j.assertLogContains("DOCKER_TLS_VERIFY=1", b);
+                story.j.assertLogNotContains("DOCKER_CERT_PATH= is not empty", b);
             }
         });
     }


### PR DESCRIPTION
[JENKINS-48437](https://issues.jenkins-ci.org/browse/JENKINS-48437)

Consume a new API introduced in https://github.com/jenkinsci/docker-commons-plugin/pull/68 that accepts a `Run` to resolve the credentials ID.