### PR TITLE
Respect word boundaries when extracting FROM image id

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
@@ -108,7 +108,7 @@ public class FromFingerprintStep extends AbstractStepImpl {
                             continue;
                         }
                         if (line.startsWith("FROM ")) {
-                            fromImage = line.substring(5);
+                            fromImage = line.substring(5).replace("\n", "").replace("\r", "");
                             continue;
                         }
                     }


### PR DESCRIPTION
in FromFingerprintStep() we extract anything after "FROM ", unfortunately it seems it assumes that everything after that is the image id, including newlines in my case which breaks things like docker.build() from docker-common-plugin which expects a 64 character string, but instead gets a 64 character string plus a newline at the end.

I had a simple pipeline to test this where I was building a docker image of helm.

```
          script {
              def dockerImage = docker.build("helm:${env.BUILD_ID}")
          }

```

And this was the error I was getting with both docker 17.03 and docker 17.05

```
[Pipeline] withEnv
[Pipeline] {
[Pipeline] container
[Pipeline] {
[Pipeline] script
[Pipeline] {
[Pipeline] sh
[helm-master] Running shell script
+ docker build -t helm:3 .
Sending build context to Docker daemon  72.19kB

Step 1/5 : FROM alpine:latest
 ---> 3fd9065eaf02
Step 2/5 : ENV HELM_VERSION 'v2.9.0'
 ---> Using cache
 ---> e5461b57cc5e
Step 3/5 : RUN apk add --update ca-certificates &&     apk add --update -t deps wget
 ---> Using cache
 ---> 108cb5ac0e22
Step 4/5 : RUN wget https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz &&     tar -xzf helm-${HELM_VERSION}-linux-amd64.tar.gz &&     mv linux-amd64/helm /usr/local/bin/ &&     rm -rf linux-amd64 helm-${HELM_VERSION}-linux-amd64.tar.gz
 ---> Using cache
 ---> fb8fc175b0c9
Step 5/5 : ENTRYPOINT /usr/local/bin/helm
 ---> Using cache
 ---> 1c5ae4794da5
Successfully built 1c5ae4794da5
[Pipeline] dockerFingerprintFrom
[Pipeline] }
[Pipeline] // script
[Pipeline] }
[Pipeline] // container
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] End of Pipeline
java.lang.IllegalArgumentException: Expecting 64-char full image ID, but got 3fd9065eaf02feaf94d68376da52541925650b81698c53c6824d92ff63f98353
EXITCODE   0
	at org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints.getFingerprintHash(DockerFingerprints.java:71)
	at org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints.forDockerInstance(DockerFingerprints.java:147)
	at org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints.forImage(DockerFingerprints.java:114)
	at org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints.forImage(DockerFingerprints.java:99)
	at org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints.addFromFacet(DockerFingerprints.java:259)
	at org.jenkinsci.plugins.docker.workflow.FromFingerprintStep$Execution.run(FromFingerprintStep.java:133)
	at org.jenkinsci.plugins.docker.workflow.FromFingerprintStep$Execution.run(FromFingerprintStep.java:85)
	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1$1.call(AbstractSynchronousNonBlockingStepExecution.java:47)
	at hudson.security.ACL.impersonate(ACL.java:290)
	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1.run(AbstractSynchronousNonBlockingStepExecution.java:44)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Finished: FAILURE
```
With this change I'm just removing the newlines.