### PR TITLE
Add tty to exec

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -242,7 +242,7 @@ public class WithContainerStep extends AbstractStepImpl {
                     } catch (InterruptedException x) {
                         throw new IOException(x);
                     }
-                    List<String> prefix = new ArrayList<>(Arrays.asList(executable, "exec"));
+                    List<String> prefix = new ArrayList<>(Arrays.asList(executable, "exec", "-t"));
                     if (ws != null) {
                         FilePath cwd = starter.pwd();
                         if (cwd != null) {


### PR DESCRIPTION
The `docker run` command always has tty support, but this plugin invokes
most commands using `exec`, which currently does not allow tty (see https://github.com/jenkinsci/docker-workflow-plugin/blob/50ad50bad2ee14eb73d1ae3ef1058b8ad76c9e5d/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java#L109)

An alternative would be to allow script writers to specify additional flags to the exec commands, the same way we can pass flags to `inside`.