### PR TITLE
Clarified consequences of not doing image.pull()

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
@@ -97,6 +97,8 @@
             <p>
                 Runs <code>docker pull</code>.
                 Not necessary before <code>run</code>, <code>withRun</code>, or <code>inside</code>.
+                However, if the image is cached locally, then that image will be used, even if there is a newer version available upstream.
+                This can lead to strange behaviour if agents have different versions of the image.
             </p>
         </dd>
         <dt><code>Image.imageName()</code></dt>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
@@ -98,7 +98,7 @@
                 Runs <code>docker pull</code>.
                 Not necessary before <code>run</code>, <code>withRun</code>, or <code>inside</code>.
                 However, if the image is cached locally, then that image will be used, even if there is a newer version available upstream.
-                This can lead to strange behaviour if agents have different versions of the image.
+                This can lead to strange behaviour if agents have different versions of the image and the image is given a floating tag like <code>latest</code> which does not permanently refer to a specific revision.
             </p>
         </dd>
         <dt><code>Image.imageName()</code></dt>


### PR DESCRIPTION
This has bitten me quite a few times, not doing image.pull() before image.inside() and similar commands can results in strange behaviors if Jenkins agents have different image versions cached locally. This commit adds a clarification in the documentation.