### PR TITLE
JENKINS-43458 : Docker stop should allow 143 as a valid exit code

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -167,7 +167,7 @@ public class DockerClient {
      */
     public void stop(@Nonnull EnvVars launchEnv, @Nonnull String containerId) throws IOException, InterruptedException {
         LaunchResult result = launch(launchEnv, false, "stop", "--time=1", containerId);
-        if (result.getStatus() != 0) {
+        if (result.getStatus() != 0 && result.getStatus() != 143) {
             throw new IOException(String.format("Failed to kill container '%s'.", containerId));
         }
         rm(launchEnv, containerId);
@@ -182,7 +182,7 @@ public class DockerClient {
     public void rm(@Nonnull EnvVars launchEnv, @Nonnull String containerId) throws IOException, InterruptedException {
         LaunchResult result;
         result = launch(launchEnv, false, "rm", "-f", containerId);
-        if (result.getStatus() != 0) {
+        if (result.getStatus() != 0 && result.getStatus() != 143) {
             throw new IOException(String.format("Failed to rm container '%s'.", containerId));
         }
     }


### PR DESCRIPTION
As the previous pull request (https://github.com/jenkinsci/docker-workflow-plugin/pull/93) seems to be dead. Here's a new one to manage exit code 143 in jenkins plugin.