### PR TITLE
JENKINS-46636 Fix dir() for older docker

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -252,7 +252,8 @@ public class WithContainerStep extends AbstractStepImpl {
                                     prefix.add("--workdir");
                                     prefix.add(path);
                                 } else {
-                                    launcher.getListener().getLogger().println("Docker version is older than 17.12, working directory will be " + ws + " not " + path);
+                                    String safePath = path.replace("'", "'\"'\"'");
+                                    starter.cmds().addAll(0, Arrays.asList("sh", "-c", "cd '" + safePath + "'; \"$@\"", "--"));
                                 }
                             }
                         }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -253,7 +253,7 @@ public class WithContainerStep extends AbstractStepImpl {
                                     prefix.add(path);
                                 } else {
                                     String safePath = path.replace("'", "'\"'\"'");
-                                    starter.cmds().addAll(0, Arrays.asList("sh", "-c", "cd '" + safePath + "'; \"$@\"", "--"));
+                                    starter.cmds().addAll(0, Arrays.asList("sh", "-c", "cd '" + safePath + "'; exec \"$@\"", "--"));
                                 }
                             }
                         }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-46636
This works around the lack of --workdir for "docker exec" in versions earlier than 17.12.
It wraps an additional shell around the sh() command which issues a "cd" before delegating.