### PR TITLE
Update DockerClient.java

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -115,7 +115,11 @@ public class DockerClient {
             argb.add("-w", workdir);
         }
         for (Map.Entry<String, String> volume : volumes.entrySet()) {
-            argb.add("-v", volume.getKey() + ":" + volume.getValue() + ":rw,z");
+            String volumeModeString = ":rw,z";
+            if (System.getProperty("os.name").contains("windows")){
+                volumeModeString = ":rw";
+            }
+            argb.add("-v", volume.getKey() + ":" + volume.getValue() + volumeModeString);
         }
         for (String containerId : volumesFromContainers) {
             argb.add("--volumes-from", containerId);


### PR DESCRIPTION
Added logic for Windows or Linux volume modes.

Unable to use docker on windows due to 'z' mode on volumes. This logic will use a different mode for windows.