### PR TITLE
Fix multifrom Dockerfile parsing

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerfileMultiFromTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerfileMultiFromTest.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.workflow;
+
+import hudson.FilePath;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+public class DockerfileMultiFromTest {
+
+    private FilePath dockerfilePath;
+
+    @Before
+    public void setUp() {
+        dockerfilePath = new FilePath(new File("src/test/resources/Dockerfile-multiFrom"));
+    }
+
+    @Test
+    public void parseDockerfile() throws IOException, InterruptedException {
+        Dockerfile dockerfile = new Dockerfile(dockerfilePath);
+        Assert.assertArrayEquals(dockerfile.getFroms().toArray(), new Object[]{"node:carbon", "node:8.9-alpine"});
+    }
+}

--- a/src/test/resources/Dockerfile-multiFrom
+++ b/src/test/resources/Dockerfile-multiFrom
@@ -1,0 +1,6 @@
+FROM node:carbon AS base
+WORKDIR /app
+FROM base AS dependencies
+FROM dependencies AS build
+FROM node:8.9-alpine AS release
+CMD ["sh"]


### PR DESCRIPTION
Fix crash on Dockerfile with `FROM <image>[@<digest>] AS <name>`:
```
java.io.IOException: Cannot retrieve .Id from 'docker inspect node:current-alpine AS release'
	at org.jenkinsci.plugins.docker.workflow.client.DockerClient.inspectRequiredField(DockerClient.java:220)
	at org.jenkinsci.plugins.docker.workflow.FromFingerprintStep$Execution.run(FromFingerprintStep.java:133)
	at org.jenkinsci.plugins.docker.workflow.FromFingerprintStep$Execution.run(FromFingerprintStep.java:85)
	at 
```
