### PR TITLE
[JENKINS-56674] Mask environment variable if they passed in case of inside docker image run

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -229,6 +229,35 @@ public class WithContainerStepTest {
         });
     }
 
+    @Issue("JENKINS-56674")
+    @Test public void testEnv() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                DockerTestUtil.assumeDocker();
+                DockerTestUtil.assumeNotWindows();
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
+                p.setDefinition(new CpsFlowDefinition(
+                    "node {\n" +
+                        "  withDockerContainer(image:'docker',\n" +
+                        "                      args:'-v /var/run/docker.sock:/var/run/docker.sock --user root') {\n" +
+                        "    env.TEST_PWD = 'pwd12345'\n" +
+                        "    withDockerContainer(image:'docker',\n" +
+                        "                        args:'-v /var/run/docker.sock:/var/run/docker.sock --user root') {\n" +
+                        "      withDockerContainer(image:'docker',\n" +
+                        "                          args:'-v /var/run/docker.sock:/var/run/docker.sock --user root') {\n" +
+                        "        sh 'echo test'\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}", true));
+                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                story.j.assertLogContains("docker exec --env ********", b);
+                story.j.assertLogNotContains("pwd12345", b);
+            }
+        });
+    }
+
     @Issue("JENKINS-27152")
     @Test public void configFile() throws Exception {
         story.addStep(new Statement() {


### PR DESCRIPTION
Resolves https://issues.jenkins-ci.org/browse/JENKINS-56674

I would like to propose and show which issue exists with masked env variables during such case
```
node {
  withDockerContainer('ubuntu') {
    env.TEST_PWD = 'pwd12345'
    withDockerContainer('ubuntu') {
      withDockerContainer('ubuntu') {
		sh('echo test')
      }
    }
  }
}
```

So the output of job will have include env variable which can contains sensitive data (first part of docker exec):
```
 6.514 [prj #1] [Pipeline] node
   6.617 [prj #1] Running on master in /Users/vkravets/work/my/docker-workflow-plugin/tmp/workspace/prj
   6.617 [prj #1] [Pipeline] {
   7.814 [prj #1] [Pipeline] withDockerContainer
   7.814 [prj #1] Jenkins does not seem to be running inside a container
   7.815 [prj #1] $ docker run -t -d -u 501:20 -w /Users/vkravets/work/my/docker-workflow-plugin/tmp/workspace/prj -v /Users/vkravets/work/my/docker-workflow-plugin/tmp/workspace/prj:/Users/vkravets/work/my/docker-workflow-plugin/tmp/workspace/prj:rw,z -v /Users/vkravets/work/my/docker-workflow-plugin/tmp/workspace/prj@tmp:/Users/vkravets/work/my/docker-workflow-plugin/tmp/workspace/prj@tmp:rw,z -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** ubuntu cat
   7.815 [prj #1] $ docker top c44d7264133f649cc80cc97aae11272e00c5023efe9c34e86d69ea71dc7beb91 -eo pid,comm
   7.815 [prj #1] [Pipeline] {
  10.504 [prj #1] [Pipeline] withDockerContainer
  10.504 [prj #1] ERROR: Failed to parse docker version. Please note there is a minimum docker version requirement of v1.7.
  10.505 [prj #1] Jenkins does not seem to be running inside a container
  10.505 [prj #1] $ docker exec --env BUILD_DISPLAY_NAME=#1 --env BUILD_ID=1 --env BUILD_NUMBER=1 --env BUILD_TAG=jenkins-prj-1 --env BUILD_URL=http://localhost:56168/jenkins/job/prj/1/ --env CLASSPATH= --env EXECUTOR_NUMBER=1 --env HUDSON_HOME=/Users/vkravets/work/my/docker-workflow-plugin/./tmp --env HUDSON_SERVER_COOKIE=586ce441e4ad2814 --env HUDSON_URL=http://localhost:56168/jenkins/ --env JENKINS_HOME=/Users/vkravets/work/my/docker-workflow-plugin/./tmp --env JENKINS_SERVER_COOKIE=586ce441e4ad2814 --env JENKINS_URL=http://localhost:56168/jenkins/ --env JOB_BASE_NAME=prj --env JOB_NAME=prj --env JOB_URL=http://localhost:56168/jenkins/job/prj/ --env NODE_LABELS=master --env NODE_NAME=master --env TEST_PWD=pwd12345 --env workspace=/Users/vkravets/work/my/docker-workflow-plugin/tmp/workspace/prj c44d7264133f649cc80cc97aae11272e00c5023efe9c34e86d69ea71dc7beb91 docker run -t -d -u 501:20 -w /Users/vkravets/work/my/docker-workflow-plugin/tmp/workspace/prj -v /Users/vkravets/work/my/docker-workflow-plugin/tmp/workspace/prj:/Users/vkravets/work/my/docker-workflow-plugin/tmp/workspace/prj:rw,z -v /Users/vkravets/work/my/docker-workflow-plugin/tmp/workspace/prj@tmp:/Users/vkravets/work/my/docker-workflow-plugin/tmp/workspace/prj@tmp:rw,z -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** ubuntu cat
```

As you can see second docker run (which is wrapped by docker exec logged all env variables) which is not security