### PR TITLE
[JENKINS-56674] Masking of environment variables passed to docker exec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.23</version>
+        <version>3.40</version>
         <relativePath />
     </parent>
     <artifactId>docker-workflow</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -292,20 +292,23 @@ public class WithContainerStep extends AbstractStepImpl {
                                                          .collect(Collectors.toList()));
                     }
 
+                    boolean[] originalMasks = starter.masks();
+                    if (originalMasks == null) {
+                        originalMasks = new boolean[starter.cmds().size()];
+                    }
+
                     // Adapted from decorateByPrefix:
                     starter.cmds().addAll(0, prefix);
-                    if (starter.masks() != null) {
-                        boolean[] masks = new boolean[starter.masks().length + prefix.size()];
-                        boolean[] masksPrefix = new boolean[masksPrefixList.size()];
 
-                        for (int i = 0; i < masksPrefix.length; i++) {
-                            masksPrefix[i] = masksPrefixList.get(i);
-                        }
-
-                        System.arraycopy(masksPrefix, 0, masks, 0, masksPrefix.length);
-                        System.arraycopy(starter.masks(), 0, masks, prefix.size(), starter.masks().length);
-                        starter.masks(masks);
+                    boolean[] masks = new boolean[originalMasks.length + prefix.size()];
+                    boolean[] masksPrefix = new boolean[masksPrefixList.size()];
+                    for (int i = 0; i < masksPrefix.length; i++) {
+                        masksPrefix[i] = masksPrefixList.get(i);
                     }
+                    System.arraycopy(masksPrefix, 0, masks, 0, masksPrefix.length);
+                    System.arraycopy(originalMasks, 0, masks, prefix.size(), originalMasks.length);
+                    starter.masks(masks);
+
                     return super.launch(starter);
                 }
                 @Override public void kill(Map<String,String> modelEnvVars) throws IOException, InterruptedException {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -239,35 +239,6 @@ public class WithContainerStepTest {
         });
     }
 
-    @Issue("JENKINS-56674")
-    @Test public void testEnv() throws Exception {
-        story.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                DockerTestUtil.assumeDocker();
-                DockerTestUtil.assumeNotWindows();
-                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
-                p.setDefinition(new CpsFlowDefinition(
-                    "node {\n" +
-                        "  withDockerContainer(image:'docker',\n" +
-                        "                      args:'-v /var/run/docker.sock:/var/run/docker.sock --user root') {\n" +
-                        "    env.TEST_PWD = 'pwd12345'\n" +
-                        "    withDockerContainer(image:'docker',\n" +
-                        "                        args:'-v /var/run/docker.sock:/var/run/docker.sock --user root') {\n" +
-                        "      withDockerContainer(image:'docker',\n" +
-                        "                          args:'-v /var/run/docker.sock:/var/run/docker.sock --user root') {\n" +
-                        "        sh 'echo test'\n" +
-                        "      }\n" +
-                        "    }\n" +
-                        "  }\n" +
-                        "}", true));
-                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-                story.j.assertLogContains("docker exec --env ********", b);
-                story.j.assertLogNotContains("pwd12345", b);
-            }
-        });
-    }
-
     @Issue("JENKINS-27152")
     @Test public void configFile() throws Exception {
         story.addStep(new Statement() {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -226,13 +226,13 @@ public class WithContainerStepTest {
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +
                     "  withDockerContainer('ubuntu') {\n" +
-                    "    withCredentials([[$class: 'FileBinding', credentialsId: 'secretfile', variable: 'FILE']]) {\n" +
-                    "      sh 'cat $FILE'\n" +
+                    "    withCredentials([file(credentialsId: 'secretfile', variable: 'FILE')]) {\n" +
+                    "      sh 'cat \"$FILE\"'\n" +
                     "    }\n" +
                     "  }\n" +
-                    "  withCredentials([[$class: 'FileBinding', credentialsId: 'secretfile', variable: 'FILE']]) {\n" +
+                    "  withCredentials([file(credentialsId: 'secretfile', variable: 'FILE')]) {\n" +
                     "    withDockerContainer('ubuntu') {\n" +
-                    "      sh 'tr \"a-z\" \"A-Z\" < $FILE'\n" +
+                    "      sh 'tr \"a-z\" \"A-Z\" < \"$FILE\"'\n" +
                     "    }\n" +
                     "  }\n" +
                     "}", true));
@@ -257,12 +257,12 @@ public class WithContainerStepTest {
                     "node {\n" +
                     "  withDockerContainer('ubuntu') {\n" +
                         "  wrap([$class: 'ConfigFileBuildWrapper', managedFiles: [[fileId: '" + config.id + "', variable: 'FILE']]]) {\n" +
-                        "    sh 'cat $FILE'\n" +
+                        "    sh 'cat \"$FILE\"'\n" +
                         "  }\n" +
                     "  }\n" +
                     "  wrap([$class: 'ConfigFileBuildWrapper', managedFiles: [[fileId: '" + config.id + "', variable: 'FILE']]]) {\n" +
                     "    withDockerContainer('ubuntu') {\n" +
-                    "      sh 'tr \"a-z\" \"A-Z\" < $FILE'\n" +
+                    "      sh 'tr \"a-z\" \"A-Z\" < \"$FILE\"'\n" +
                     "    }\n" +
                     "  }\n" +
                     "}", true));


### PR DESCRIPTION
[JENKINS-56674](https://issues.jenkins-ci.org/browse/JENKINS-56674) Subsumes #166 by @vkravets.

I consider this a security hardening. Suppose you have some plugin which uses `Launcher`, calls `env` on a sensitive variable, and does _not_ use `.quiet(true)`. Normally it will look like this in the log:

    $ command with args

If you wrapped in `withDockerContainer` before this fix:

    $ docker exec --env VAR=value abc123def456 command with args

and after:

    $ docker exec --env ******** abc123def456 command with args

Or for old versions of Docker,

    $ docker exec abc123def456 env VAR=value command with args

vs.

    $ docker exec abc123def456 env ******** command with args