### PR TITLE
[JENKINS-56888] Handle edge case in ControlGroup

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
@@ -51,12 +51,15 @@ public class ControlGroup {
 
     public String getContainerId() throws IOException {
         if (group.contains("/docker/")) {
-            // 4:cpuset:/system.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope
             // 2:cpu:/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
             // 2:cpu:/docker-ce/docker/7cacbc548047c130ae50653548f037285806d49c0c4c1543925cffb8873ed213
             // 10:cpu,cpuacct:/docker/a9f3c3932cd81c4a74cc7e0a18c3300255159512f1d000545c42895adaf68932/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
             // 3:cpu:/docker/4193df6bcf5fce75f3fc77f303b2ac06fb664adeb269b959b7ae17b3f8dcf329/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
             int i = group.lastIndexOf('/');
+            // https://issues.jenkins-ci.org/browse/JENKINS-56888
+            if (group.substring(group.lastIndexOf("/docker/")).contains("/user/")) {
+                i = group.lastIndexOf("/docker/")+7;
+            }
             if (group.length() < i+1+64) throw new IOException("Unexpected cgroup syntax "+group);
             return group.substring(i+1, i+1+64);
         }
@@ -67,6 +70,7 @@ public class ControlGroup {
             return group.substring(i+1, i+1+64);
         }
         if (group.contains("/docker-")) {
+            // 4:cpuset:/system.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope
             // 8:cpuset:/kubepods.slice/kubepods-pod9c26dfb6_b9c9_11e7_bfb9_02c6c1fc4861.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope
             int i = group.lastIndexOf("/docker-");
             if (group.length() < i+8+64) throw new IOException("Unexpected cgroup syntax "+group);

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroupTest.java
@@ -23,7 +23,9 @@ public class ControlGroupTest {
             "8:cpuset:/kubepods.slice/kubepods-pod9c26dfb6_b9c9_11e7_bfb9_02c6c1fc4861.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope",
             "8:cpuset:/kubepods/besteffort/pod60070ae4-c63a-11e7-92b3-0adc1ac11520/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
             "7:cpu:/ecs/0410eff2-7e59-4111-823e-1e0d98ef7f30/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
-            "2:cpu:/docker-ce/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b"
+            "2:cpu:/docker-ce/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
+            "2:cpu:/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b/user/jenkins/0"
+
         };
 
         for (final String possibleCgroupString : possibleCgroupStrings) {


### PR DESCRIPTION
See [[JENKINS-56888]](https://issues.jenkins-ci.org/browse/JENKINS-56888)

Addresses an edge case when determining whether the DockerClient instance is running inside a container. If the node that's used as the DockerClient is running in a Ubuntu 16+ based container and it was launched via SSH, there's a trailing part of the cgroup path that throws off `ControlGroup.getContainerId()`