### PR TITLE
Actually show human-readable exception when no FROM in Dockerfile

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
@@ -97,11 +97,11 @@ public class FromFingerprintStep extends AbstractStepImpl {
             FilePath dockerfilePath = workspace.child(step.dockerfile);
             Dockerfile dockerfile = new Dockerfile(dockerfilePath);
             Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, step.commandLine);
-            String fromImage = dockerfile.getFroms().getLast();
 
             if (dockerfile.getFroms().isEmpty()) {
                 throw new AbortException("could not find FROM instruction in " + dockerfilePath);
             }
+            String fromImage = dockerfile.getFroms().getLast();
             if (buildArgs != null) {
                 // Fortunately, Docker uses the same EnvVar syntax as Jenkins :)
                 fromImage = Util.replaceMacro(fromImage, buildArgs);


### PR DESCRIPTION
Query for last FROM in Dockerfile after checking if FROM list is empty.

Because this was previously done in the opposite order, the human-readable exception message was stifled by the unhandled NoSuchElementException thrown by "getLast".