### PR TITLE
Defer getting the last images from the FROM list, until after checkin…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
@@ -97,11 +97,12 @@ public class FromFingerprintStep extends AbstractStepImpl {
             FilePath dockerfilePath = workspace.child(step.dockerfile);
             Dockerfile dockerfile = new Dockerfile(dockerfilePath);
             Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, step.commandLine);
-            String fromImage = dockerfile.getFroms().getLast();
 
             if (dockerfile.getFroms().isEmpty()) {
                 throw new AbortException("could not find FROM instruction in " + dockerfilePath);
             }
+            String fromImage = dockerfile.getFroms().getLast();
+
             if (buildArgs != null) {
                 // Fortunately, Docker uses the same EnvVar syntax as Jenkins :)
                 fromImage = Util.replaceMacro(fromImage, buildArgs);


### PR DESCRIPTION
…g that there are any images at all - otherwise this will fail, if FROM line can not be found

We saw this in the wild, because we had an image with a unicode BOM before the FROM. This is handled by Docker, but no by this plugin. This pr does not solve that problem, but improves the error message - you get a hint that the plugin can not find the FROM line, instead of a generic java.util.NoSuchElementException.