### PR TITLE
Support non-capitalized dockerfile syntax

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/Dockerfile.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/Dockerfile.java
@@ -70,13 +70,13 @@ public final class Dockerfile {
                     if (line.startsWith("#")) {
                         continue;
                     }
-                    if (line.startsWith(ARG)) {
+                    if (line.toUpperCase().startsWith(ARG)) {
                         String[] keyVal = parseDockerfileArg(line.substring(4));
                         args.put(keyVal[0], keyVal[1]);
                         continue;
                     }
 
-                    if (line.startsWith(FROM)) {
+                    if (line.toUpperCase().startsWith(FROM)) {
                         froms.add(line.substring(5));
                         continue;
                     }


### PR DESCRIPTION
docker supports FROM lines using lowercase, even if uppercase is the convention.  This should get things working either way.