### PR TITLE
JENKINS-45473 Run user inside with all groups membership.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -181,7 +181,7 @@ public class WithContainerStep extends AbstractStepImpl {
                 volumes.put(tmp, tmp);
             }
 
-            container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ "cat");
+            container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), dockerClient.whatAmI(), /* expected to hang until killed */ "cat");
             final List<String> ps = dockerClient.listProcess(env, container);
             if (!ps.contains("cat")) {
                 listener.error(

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
@@ -60,7 +60,7 @@ public class DockerClientTest {
         EnvVars launchEnv = newLaunchEnv();
         String containerId =
                 dockerClient.run(launchEnv, "learn/tutorial", null, null, Collections.<String, String>emptyMap(), Collections.<String>emptyList(), new EnvVars(),
-                        dockerClient.whoAmI(), "cat");
+                        dockerClient.whoAmI(), dockerClient.whatAmI(), "cat");
         Assert.assertEquals(64, containerId.length());
         ContainerRecord containerRecord = dockerClient.getContainerRecord(launchEnv, containerId);
         Assert.assertEquals(dockerClient.inspect(launchEnv, "learn/tutorial", ".Id"), containerRecord.getImageId());


### PR DESCRIPTION
Adds all groups using [--group-add](https://docs.docker.com/engine/reference/run/#additional-groups).

When using docker.inside() or a Docker agent, --user is passed to assume the Jenkins user's identity, but this only works for the user id and primary group id.  This patch adds all additional groups (by id) the user may belong to.

The primary motivation is the lack of membership in the "docker" group inside the agent, which makes running docker commands not possible without some kind of dirty workaround.