### PR TITLE
--build-arg can accept key only

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerUtils.java
@@ -51,13 +51,13 @@ public final class DockerUtils {
                 String keyVal = arguments[i+1];
 
                 String parts[] = keyVal.split("=", 2);
-                if (parts.length != 2) {
-                    throw new IllegalArgumentException("Illegal syntax for --build-arg " + keyVal + ", need KEY=VALUE");
+                if (parts.length == 2) {
+                    String key = parts[0];
+                    String value = parts[1];
+                    result.put(key, value);
+                } else {
+                    // Single argument --build-arg params are allowed, but cannot be parsed here.
                 }
-                String key = parts[0];
-                String value = parts[1];
-
-                result.put(key, value);
             }
         }
         return result;


### PR DESCRIPTION
Not sure what should happen here, but according to the docs it is allowed:

> You may also use the --build-arg flag without a value, in which case the value from the local environment will be propagated into the Docker container being built:
- https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg

I am not a java dev, any help is appreciated.