### PR TITLE
bugfix(dockerutils): build-arg from ENV

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
@@ -96,7 +96,7 @@ public class FromFingerprintStep extends AbstractStepImpl {
         @Override protected Void run() throws Exception {
             FilePath dockerfilePath = workspace.child(step.dockerfile);
             Dockerfile dockerfile = new Dockerfile(dockerfilePath);
-            Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, step.commandLine);
+            Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, step.commandLine, env);
             String fromImage = dockerfile.getFroms().getLast();
 
             if (dockerfile.getFroms().isEmpty()) {


### PR DESCRIPTION
docker build supports adding a build-arg without an explicit
value assignment

docker will then just pass an existing environment variable with the
same name from its environment and make it available as ARG in the
dockerfile

Unfortunatly the FromFingerprintStep relied on Dockerutils where the
build-arg is checked for KEY=VALUE assignment

this bugfix make --build-arg FOO possible