### PR TITLE
Check for empty getFroms() before use a last element of it

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStep.java
@@ -97,11 +97,10 @@ public class FromFingerprintStep extends AbstractStepImpl {
             FilePath dockerfilePath = workspace.child(step.dockerfile);
             Dockerfile dockerfile = new Dockerfile(dockerfilePath);
             Map<String, String> buildArgs = DockerUtils.parseBuildArgs(dockerfile, step.commandLine);
-            String fromImage = dockerfile.getFroms().getLast();
-
             if (dockerfile.getFroms().isEmpty()) {
                 throw new AbortException("could not find FROM instruction in " + dockerfilePath);
             }
+            String fromImage = dockerfile.getFroms().getLast();
             if (buildArgs != null) {
                 // Fortunately, Docker uses the same EnvVar syntax as Jenkins :)
                 fromImage = Util.replaceMacro(fromImage, buildArgs);


### PR DESCRIPTION
At various cases (for example, someone type 'From' instead of 'FROM' at a Dockerfile) `froms` list is empty. As a result `getFroms().getLast()` statement throws an exception.
```
java.util.NoSuchElementException
	at java.util.LinkedList.getLast(LinkedList.java:257)
	at org.jenkinsci.plugins.docker.workflow.FromFingerprintStep$Execution.run(FromFingerprintStep.java:100)
```

Solution is to check before actual usage