### PR TITLE
Fix : parsing of dockerfile when instructions are not case-sensitive

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/Dockerfile.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/Dockerfile.java
@@ -70,13 +70,13 @@ public final class Dockerfile {
                     if (line.startsWith("#")) {
                         continue;
                     }
-                    if (line.startsWith(ARG)) {
+                    if (line.toUpperCase().startsWith(ARG)) {
                         String[] keyVal = parseDockerfileArg(line.substring(4));
                         args.put(keyVal[0], keyVal[1]);
                         continue;
                     }
 
-                    if (line.startsWith(FROM)) {
+                    if (line.toUpperCase().startsWith(FROM)) {
                         froms.add(line.substring(5));
                         continue;
                     }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerfileTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerfileTest.java
@@ -49,6 +49,13 @@ public class DockerfileTest {
         Assert.assertThat(dockerfile.getArgs().keySet(), IsCollectionWithSize.hasSize(2));
         Assert.assertThat(dockerfile.getArgs().keySet(), IsCollectionContaining.hasItems("REGISTRY_URL", "TAG"));
     }
+    
+    @Test public void parseDockerfileIgnoreCase() throws IOException, InterruptedException {
+    	FilePath dockerFilePath = new FilePath(new File("src/test/resources/Dockerfile-lowercaseFrom")); 
+    	Dockerfile dockerfile = new Dockerfile(dockerFilePath);
+    	Assert.assertThat(dockerfile.getFroms().getLast(), IsEqual.equalTo("${REGISTRY_URL}hello-world:${TAG}"));
+    	Assert.assertThat(dockerfile.getArgs().keySet(), IsCollectionWithSize.hasSize(2));
+    }
 }
 
 

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerfileTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerfileTest.java
@@ -51,7 +51,7 @@ public class DockerfileTest {
     }
     
     @Test public void parseDockerfileIgnoreCase() throws IOException, InterruptedException {
-    	FilePath dockerFilePath = new FilePath(new File("src/test/resources/Dockerfile-lowercaseFrom")); 
+    	FilePath dockerFilePath = new FilePath(new File("src/test/resources/Dockerfile-ignoreCase")); 
     	Dockerfile dockerfile = new Dockerfile(dockerFilePath);
     	Assert.assertThat(dockerfile.getFroms().getLast(), IsEqual.equalTo("${REGISTRY_URL}hello-world:${TAG}"));
     	Assert.assertThat(dockerfile.getArgs().keySet(), IsCollectionWithSize.hasSize(2));

--- a/src/test/resources/Dockerfile-ignoreCase
+++ b/src/test/resources/Dockerfile-ignoreCase
@@ -1,0 +1,4 @@
+# Dockerfile with FROM ARGs and default values
+ARG REGISTRY_URL
+arg TAG=latest
+from ${REGISTRY_URL}hello-world:${TAG}


### PR DESCRIPTION
Even though best practice for typing the instructions in dockerfile is UPPER CASE but instructions are not case-sensitive in dockerfile.

Presently this scenario is not considered in docker-workflow-plugin.

As a result, if there is a Dockerfile which does not follow UPPERCASE for instructions fails with Jenkins docker-workflow-plugin with error :

```
java.util.NoSuchElementException
	at java.util.LinkedList.getLast(LinkedList.java:257)
	at org.jenkinsci.plugins.docker.workflow.FromFingerprintStep$Execution.run(FromFingerprintStep.java:100) 
```


This pull request addresses this error.Also added test data in resource folder along with unit tests