### PR TITLE
DockerFile parse case sensitive bug fix

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/Dockerfile.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/Dockerfile.java
@@ -70,13 +70,13 @@ public final class Dockerfile {
                     if (line.startsWith("#")) {
                         continue;
                     }
-                    if (line.startsWith(ARG)) {
+                    if (line.toUpperCase().startsWith(ARG)) {
                         String[] keyVal = parseDockerfileArg(line.substring(4));
                         args.put(keyVal[0], keyVal[1]);
                         continue;
                     }
 
-                    if (line.startsWith(FROM)) {
+                    if (line.toUpperCase().startsWith(FROM)) {
                         froms.add(line.substring(5));
                         continue;
                     }


### PR DESCRIPTION
Dockerfile instructions are case insensitive. (https://docs.docker.com/v17.09/engine/reference/builder/#format)

```
From ubuntu:14.04
```
is a valid Dockerfile instruction, whose parsing fails.