### PR TITLE
JENKINS-50857 Added support for Docker instance on Windows

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -183,9 +183,13 @@ public class WithContainerStep extends AbstractStepImpl {
                 volumes.put(tmp, tmp);
             }
 
-            container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ "cat");
+            String command = "cat";
+            if (dockerClient.isWindowsHost()) {
+                command = "sort.exe";
+            }
+            container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ command);
             final List<String> ps = dockerClient.listProcess(env, container);
-            if (!ps.contains("cat")) {
+            if (!ps.contains(command)) {
                 listener.error(
                     "The container started but didn't run the expected command. " +
                         "Please double check your ENTRYPOINT does execute the command passed as docker run argument, " +

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -82,8 +82,8 @@ public class DockerClient {
     private final Launcher launcher;
     private final @CheckForNull Node node;
     private final @CheckForNull String toolName;
-    private static Boolean isDockerInitialized = false;
-    private static Boolean isDockerOnWindows = false;
+    private Boolean isDockerInitialized = false;
+    private Boolean isDockerOnWindows = false;
 
     public DockerClient(@Nonnull Launcher launcher, @CheckForNull Node node, @CheckForNull String toolName) {
         this.launcher = launcher;


### PR DESCRIPTION
We have been using the docker-worflow plugin with a Windows docker host for some timenow. While not all features are fully supported I thought I would like to contribute this, especially as the feature has also been discussed in the context of issue JENKINS-50857.
I have been careful in trying to avoid any breaking changes, the feature is only enabled if the docker daemon reports that it is running on Windows.