### PR TITLE
Clean up an empty env var during `docker exec`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -266,10 +266,11 @@ public class WithContainerStep extends AbstractStepImpl {
                     Set<String> envReduced = new TreeSet<String>(Arrays.asList(starter.envs()));
                     envReduced.removeAll(Arrays.asList(envHost));
 
-                    // Remove PATH during `exec` as well.
+                    // Remove PATH and an empty var during `exec` as well.
                     Iterator<String> it = envReduced.iterator();
                     while (it.hasNext()) {
-                        if (it.next().startsWith("PATH=")) {
+                        String envItem = it.next();
+                        if (envItem.startsWith("PATH=") || envItem.startsWith("=")) {
                             it.remove();
                         }
                     }


### PR DESCRIPTION
I have run into [this issue](https://issues.jenkins-ci.org/browse/JENKINS-58657). An **sh** step just hung for 5 minutes and then failed.

The step log says:
`invalid argument "=" for "-e, --env" flag: invalid environment variable: =`

The Jenkins log says:
`FINE: (exec) reduced environment: [=, BRANCH_NAME=jenkins, BUILD_DISPLAY_NAME=#134, BUILD_ID=134, BUILD_NUMBER=134, ....]`

Let's remove that empty variable.