### PR TITLE
Add Container ID detection for GitHub Actions

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
@@ -78,6 +78,12 @@ public class ControlGroup {
             if (group.length() < i+1+64) throw new IOException("Unexpected cgroup syntax "+group);
             return group.substring(i+1, i+1+64);
         }
+        if (group.startsWith("/actions_job/")) {
+            // 12:freezer:/actions_job/ddecc467e1fb3295425e663efb6531282c1c936f25a3eeb7bb64e7b0fc61a216
+            int i = group.lastIndexOf('/');
+            if (group.length() < i+1+64) throw new IOException("Unexpected cgroup syntax "+group);
+            return group.substring(i+1, i+1+64);
+        }
 
         return null;
     }


### PR DESCRIPTION
If you currently run a [Jenkinsfile runner within a Docker container within GitHub Actions](https://blogs.sap.com/2019/09/13/running-sap-cloud-sdk-pipeline-on-github-actions/), spawning docker containers from this Jenkins instance will not detect that we are already running in a docker container:

> [Pipeline] withDockerContainer
Jenkins does not seem to be running inside a container

Looking into https://github.com/jenkinsci/docker-workflow-plugin/blob/50ad50bad2ee14eb73d1ae3ef1058b8ad76c9e5d/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java#L328 and https://github.com/jenkinsci/docker-workflow-plugin/blob/50ad50bad2ee14eb73d1ae3ef1058b8ad76c9e5d/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java#L52, it looks as if Jenkins is parsing `/proc/self/cgroup` to determine whether it is running in a container.

As GitHub Action is using a cgroup called `/actions_job` that is not yet recognized by Jenkins, I added the parsing logic to it.

/cc @fwilhe @ndeloof 