### PR TITLE
Removing defined stop timeout

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -166,7 +166,7 @@ public class DockerClient {
      * @param containerId The container ID.
      */
     public void stop(@Nonnull EnvVars launchEnv, @Nonnull String containerId) throws IOException, InterruptedException {
-        LaunchResult result = launch(launchEnv, false, "stop", "--time=1", containerId);
+        LaunchResult result = launch(launchEnv, false, "stop", "--time=5", containerId);
         if (result.getStatus() != 0) {
             throw new IOException(String.format("Failed to kill container '%s'.", containerId));
         }


### PR DESCRIPTION
When a SIGTERM is sent the process is safely pruned however the existing limit of 1 second is not always enough for the application to respect the signal. As if this is breached and causes the pipeline to fail this can cause any larger containers to be unusable. Dockers default value is 10 seconds, extending to 5 seconds, ideally this could be customizable if others have similar concerns