### PR TITLE
[JENKINS-59172] - Use GitHub as a source of the plugin's documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       </license>
     </licenses>
     
-    <url>https://wiki.jenkins.io/display/JENKINS/Docker+Pipeline+Plugin</url>
+    <url>https://github.com/jenkinsci/docker-workflow-plugin</url>
     <scm>
       <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
       <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>


### PR DESCRIPTION
The real documentation is on the CloudBees site, but at least we will have one site less to maintain