### PR TITLE
JENKINS-48417 Add the ability to run docker container in foreground

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -135,9 +135,9 @@ class Docker implements Serializable {
             }
         }
 
-        public Container run(String args = '', String command = "") {
+        public Container run(String args = '', String command = "", boolean foreground = false) {
             docker.node {
-                def container = docker.script."${docker.shell()}"(script: "docker run -d${args != '' ? ' ' + args : ''} ${id}${command != '' ? ' ' + command : ''}", returnStdout: true).trim()
+                def container = docker.script."${docker.shell()}"(script: "docker run ${!foreground ? '-d' : ''} ${args != '' ? ' ' + args : ''} ${id}${command != '' ? ' ' + command : ''}", returnStdout: true).trim()
                 new Container(docker, container)
             }
         }


### PR DESCRIPTION
Following the linked issue, we are missing a way in order to run a container which is only playing foreground command.

e.g.: this is quite useful for a Dockerfile used for compilation.

I think that such feature is only meaningful in the `run` step.
Effectively, `withRun` & `inside` are dedicated to interact with the container, whereas `run` in foreground means that the image has a self-sufficent embedded command.