### PR TITLE
Containerize workspace paths when running Linux container on Windows host

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
@@ -36,10 +36,10 @@ public class WindowsDockerClient extends DockerClient {
         }
 
         if (workdir != null) {
-            argb.add("-w", workdir);
+            argb.add("-w", containerizePathIfNeeded(workdir, null));
         }
         for (Map.Entry<String, String> volume : volumes.entrySet()) {
-            argb.add("-v", volume.getKey() + ":" + volume.getValue());
+            argb.add("-v", volume.getKey() + ":" + containerizePathIfNeeded(volume.getValue(), null));
         }
         for (String containerId : volumesFromContainers) {
             argb.add("--volumes-from", containerId);
@@ -80,7 +80,7 @@ public class WindowsDockerClient extends DockerClient {
         }
         return processes;
     }
-
+    
     @Override
     public Optional<String> getContainerIdIfContainerized() throws IOException, InterruptedException {
         if (node == null ||
@@ -111,10 +111,10 @@ public class WindowsDockerClient extends DockerClient {
         }
     }
 
-    private LaunchResult launch(EnvVars env, boolean quiet, FilePath workDir, String... args) throws IOException, InterruptedException {
+    protected LaunchResult launch(EnvVars env, boolean quiet, FilePath workDir, String... args) throws IOException, InterruptedException {
         return launch(env, quiet, workDir, new ArgumentListBuilder(args));
     }
-    private LaunchResult launch(EnvVars env, boolean quiet, FilePath workDir, ArgumentListBuilder argb) throws IOException, InterruptedException {
+    protected LaunchResult launch(EnvVars env, boolean quiet, FilePath workDir, ArgumentListBuilder argb) throws IOException, InterruptedException {
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.log(Level.FINE, "Executing command \"{0}\"", argb);
         }
@@ -133,5 +133,11 @@ public class WindowsDockerClient extends DockerClient {
         result.setErr(err.toString(charsetName));
 
         return result;
+    }
+
+    @Override
+    public String runCommand()
+    {
+        return "cmd.exe";
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsLinuxDockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsLinuxDockerClient.java
@@ -1,0 +1,67 @@
+package org.jenkinsci.plugins.docker.workflow.client;
+
+import com.google.common.base.Optional;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Node;
+import hudson.util.ArgumentListBuilder;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class WindowsLinuxDockerClient extends WindowsDockerClient {
+    private static final Logger LOGGER = Logger.getLogger(WindowsLinuxDockerClient.class.getName());
+
+    private final Launcher launcher;
+    private final Node node;
+
+    public WindowsLinuxDockerClient(@Nonnull Launcher launcher, @CheckForNull Node node, @CheckForNull String toolName) {
+        super(launcher, node, toolName);
+        this.launcher = launcher;
+        this.node = node;
+    }
+
+    @Override
+    public List<String> listProcess(@Nonnull EnvVars launchEnv, @Nonnull String containerId) throws IOException, InterruptedException {
+        LaunchResult result = launch(launchEnv, false, null, "docker", "top", containerId);
+        if (result.getStatus() != 0) {
+            throw new IOException(String.format("Failed to run top '%s'. Error: %s", containerId, result.getErr()));
+        }
+        List<String> processes = new ArrayList<>();
+        try (Reader r = new StringReader(result.getOut());
+             BufferedReader in = new BufferedReader(r)) {
+            String line;
+            in.readLine(); // ps header
+            while ((line = in.readLine()) != null) {
+                final StringTokenizer stringTokenizer = new StringTokenizer(line, " ");
+                if (stringTokenizer.countTokens() < 4) {
+                    throw new IOException("Unexpected `docker top` output : "+line);
+                }
+
+                stringTokenizer.nextToken(); // PID
+                stringTokenizer.nextToken(); // USER
+                stringTokenizer.nextToken(); // TIME
+                processes.add(stringTokenizer.nextToken()); // COMMAND
+            }
+        }
+        return processes;
+    }
+
+    @Override
+    public String runCommand()
+    {
+        return "cat";
+    }
+
+    @Override
+    public boolean needToContainerizePath() {
+        return true;
+    }
+}


### PR DESCRIPTION
This attempts to address this reported issue:

https://issues.jenkins-ci.org/browse/JENKINS-60473

The main problem is that the plugin uses the host's absolute path for the workspace as a volume mount in the Docker container. This works fine when the OS matches between host and container (e.g., Linux/Linux or Windows/Windows). When running Linux containers on a Windows host, the Windows-style paths (with a drive letter) are not valid.

The code change in this fork detects that it's a mixed environment and converts workspace paths to Linux-compatible versions. This is running in production for my use-case, but it has not been robustly tested.