### PR TITLE
Remove automatic fingerprinting from Image.inside() step.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -206,7 +206,6 @@ public class WithContainerStep extends AbstractStepImpl {
                         "Alternatively you can force image entrypoint to be disabled by adding option `--entrypoint=''`.");
             }
 
-            DockerFingerprints.addRunFacet(dockerClient.getContainerRecord(env, container), run);
             ImageAction.add(step.image, run);
             getContext().newBodyInvoker().
                     withContext(BodyInvoker.mergeLauncherDecorators(getContext().get(LauncherDecorator.class), new Decorator(container, envHost, ws, toolName, dockerVersion))).

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import org.jenkinsci.plugins.docker.commons.fingerprint.DockerFingerprints;
 import org.jenkinsci.plugins.docker.commons.tools.DockerTool;
 import org.jenkinsci.plugins.docker.workflow.client.DockerClient;
 import org.jenkinsci.plugins.docker.workflow.client.WindowsDockerClient;

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/DockerDSL/help.jelly
@@ -47,7 +47,6 @@
                 Runs <code>docker build</code> to create and tag the specified image from a <code>Dockerfile</code> in the current directory.
                 Additional <code>args</code> may be added, such as <code>'-f Dockerfile.other --pull --build-arg http_proxy=http://192.168.1.1:3128 .'</code>. Like <code>docker build</code>, <code>args</code> must end with the build context.
                 Returns the resulting <code>Image</code> object.
-                Records a <code>FROM</code> fingerprint in the build.
             </p>
         </dd>
         <dt><code>Image.id</code></dt>
@@ -62,7 +61,6 @@
                 Uses <code>docker run</code> to run the image, and returns a <code>Container</code> which you could <code>stop</code> later.
                 Additional <code>args</code> may be added, such as <code>'-p 8080:8080 --memory-swap=-1'</code>.
                 Optional <code>command</code> is equivalent to Docker command specified after the image.
-                Records a run fingerprint in the build.
             </p>
         </dd>
         <dt><code>Image.withRun[(args[, command])] {…}</code></dt>


### PR DESCRIPTION
Automatic fingerprinting was removed in PR #180, but for some reason Image.inside() was left unchanged.

This is a for from a pull request in docker-common plugin, https://github.com/jenkinsci/docker-commons-plugin/pull/85

Also removes incorrect documentation that was missed in PR #180.