### PR TITLE
Issue when cat entrypoint takes time to execute

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -144,6 +144,7 @@ public class DockerClient {
         if (result.getStatus() != 0) {
             throw new IOException(String.format("Failed to run top '%s'. Error: %s", containerId, result.getErr()));
         }
+        LOGGER.log(Level.FINE, "result: " + result.getOut());
         List<String> processes = new ArrayList<>();
         try (Reader r = new StringReader(result.getOut());
              BufferedReader in = new BufferedReader(r)) {


### PR DESCRIPTION
Hello
I have found a kind of issue when the entrypoint takes too much time to execute, in this case the 'cat' command that is checked in the code fails with a Error message. Anyway, the plugin keeps going successfully:
see logs: ps: [entrypoint.sh, sudo, service, sshd, sshd-gen-keys-s, ssh-keygen]

Just waiting some time and retrying once solves this issue.
see logs after retry: ps: [cat, sshd]
-> works.
Thanks to integrate such mechanism.
Patrick