### PR TITLE
Impose a 15s timeout on sudo operations

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -42,6 +42,7 @@ import java.util.logging.Level;
 import hudson.util.VersionNumber;
 import java.io.IOException;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
@@ -119,7 +120,9 @@ public class WithContainerStepTest {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 DockerTestUtil.assumeDocker();
-                Assume.assumeThat("we are in an interactive environment and can pause dockerd", new ProcessBuilder("sudo", "pgrep", "dockerd").inheritIO().start().waitFor(), Matchers.is(0));
+                Process proc = new ProcessBuilder("sudo", "pgrep", "dockerd").inheritIO().start();
+                proc.waitFor(15, TimeUnit.SECONDS);
+                Assume.assumeThat("we are in an interactive environment and can pause dockerd", proc.exitValue(), Matchers.is(0));
                 logging.record("org.jenkinsci.plugins.workflow.support.concurrent.Timeout", Level.FINE); // TODO use Timeout.class when workflow-support 2.13+
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
@@ -135,11 +138,15 @@ public class WithContainerStepTest {
                 try {
                     WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                     story.j.waitForMessage("+ sleep infinity", b);
-                    Assume.assumeThat(new ProcessBuilder("sudo", "killall", "-STOP", "dockerd").inheritIO().start().waitFor(), Matchers.is(0));
+                    proc = new ProcessBuilder("sudo", "killall", "-STOP", "dockerd").inheritIO().start();
+                    proc.waitFor(15, TimeUnit.SECONDS);
+                    Assume.assumeThat("could suspend dockerd", proc.exitValue(), Matchers.is(0));
                     try {
                         story.j.assertBuildStatus(Result.ABORTED, story.j.waitForCompletion(b));
                     } finally {
-                        Assume.assumeThat(new ProcessBuilder("sudo", "killall", "-CONT", "dockerd").inheritIO().start().waitFor(), Matchers.is(0));
+                        proc = new ProcessBuilder("sudo", "killall", "-CONT", "dockerd").inheritIO().start();
+                        proc.waitFor(15, TimeUnit.SECONDS);
+                        Assume.assumeThat("could resume dockerd", proc.exitValue(), Matchers.is(0));
                     }
                 } finally {
                     DockerClient.CLIENT_TIMEOUT = origTimeout;


### PR DESCRIPTION
Amends #86 & #107 to not let the test run to full 3m timeout when `sudo` prompts for authentication, as it does on some PCT builders.