### PR TITLE
less noise during pull of the image

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -131,7 +131,7 @@ class Docker implements Serializable {
 
         public void pull() {
             docker.node {
-                docker.script."${docker.shell()}" "docker pull ${imageName()}"
+                docker.script."${docker.shell()}" "docker pull -q ${imageName()}"
             }
         }
 


### PR DESCRIPTION
* reference https://docs.docker.com/engine/reference/commandline/image_pull/
### Description
* Jenkins log have a lot of unnecessary progress of pulling image, the flag should supress these
