### PR TITLE
[JENKINS-58732] Moving Docker agent functionality

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,4 @@
-buildPlugin()
-
+buildPlugin(platforms: [
+    'linux',
+    'windows && !windock' // TODO Docker-based tests fail on 2019
+])

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.150.3</jenkins.version>
         <java.level>8</java.level>
-        <pipeline-model-definition-plugin.version>1.5.1-SNAPSHOT</pipeline-model-definition-plugin.version> <!-- TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/372 -->
+        <pipeline-model-definition-plugin.version>1.5.1-rc1757.11984679b9a1</pipeline-model-definition-plugin.version> <!-- TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/372 -->
     </properties>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <workflow-step-api-plugin.version>2.18</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>2.12</workflow-support-plugin.version>
         <workflow-cps-plugin.version>2.25</workflow-cps-plugin.version>
+        <pipeline-model-definition-plugin.version>1.5.1-SNAPSHOT</pipeline-model-definition-plugin.version> <!-- TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/372 -->
     </properties>
     <repositories>
         <repository>
@@ -85,6 +86,16 @@
             <artifactId>workflow-step-api</artifactId>
             <version>${workflow-step-api-plugin.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkinsci.plugins</groupId>
+            <artifactId>pipeline-model-extensions</artifactId>
+            <version>${pipeline-model-definition-plugin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloudbees-folder</artifactId>
+            <version>6.1.0</version>
+        </dependency>
         <dependency> <!-- SemaphoreStep -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
@@ -127,6 +138,13 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>config-file-provider</artifactId>
             <version>2.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkinsci.plugins</groupId>
+            <artifactId>pipeline-model-definition</artifactId>
+            <version>${pipeline-model-definition-plugin.version}</version>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -160,4 +160,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties combine.children="append">
+                        <property>
+                            <!-- TODO copied from pipeline-model-definition; better to docker pull images before invoking timeout -->
+                            <name>jenkins.test.timeout</name>
+                            <value>600</value>
+                        </property>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.150.3</jenkins.version>
         <java.level>8</java.level>
-        <pipeline-model-definition-plugin.version>1.5.1-rc1757.11984679b9a1</pipeline-model-definition-plugin.version> <!-- TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/372 -->
+        <pipeline-model-definition-plugin.version>1.5.1</pipeline-model-definition-plugin.version>
     </properties>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>6.9</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>6.1.0</version>
+            <version>6.9</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,36 @@
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
             <version>${pipeline-model-definition-plugin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
             <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkinsci.plugins</groupId>
+            <artifactId>pipeline-model-definition</artifactId>
+            <version>${pipeline-model-definition-plugin.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-test-harness-tools</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent.java
@@ -110,15 +110,17 @@ public abstract class AbstractDockerAgent<D extends AbstractDockerAgent<D>> exte
     public void initialize(Map<String, DeclarativeOption> options, boolean explicitAgentInStage) {
         if (options.get(ContainerPerStage.SYMBOL) != null) {
             if (!inStage) {
+                // If we're on the root, make sure we switch to basically just doing a label
                 containerPerStageRoot = true;
             } else if (!explicitAgentInStage) {
+                // While if we're on a stage that doesn't have an explicit agent, make sure we reuse the node
                 reuseNode = true;
             }
         }
     }
 
     @Override
-    public boolean useRootAgent(Map<String, DeclarativeOption> options) {
+    public boolean reuseRootAgent(Map<String, DeclarativeOption> options) {
         return options.get(ContainerPerStage.SYMBOL) != null;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent.java
@@ -1,0 +1,125 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import java.util.Map;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption;
+import org.jenkinsci.plugins.docker.workflow.declarative.ContainerPerStage;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public abstract class AbstractDockerAgent<D extends AbstractDockerAgent<D>> extends DeclarativeAgent<D> {
+    protected String label;
+    protected String args = "";
+    protected String registryUrl;
+    protected String registryCredentialsId;
+    protected String customWorkspace;
+    protected boolean reuseNode;
+    protected boolean containerPerStageRoot;
+
+    public @Nullable
+    String getRegistryUrl() {
+        return registryUrl;
+    }
+
+    @DataBoundSetter
+    public void setRegistryUrl(String registryUrl) {
+        this.registryUrl = registryUrl;
+    }
+
+    public @Nullable String getRegistryCredentialsId() {
+        return registryCredentialsId;
+    }
+
+    @DataBoundSetter
+    public void setRegistryCredentialsId(String registryCredentialsId) {
+        this.registryCredentialsId = registryCredentialsId;
+    }
+
+    public boolean getReuseNode() {
+        return reuseNode;
+    }
+
+    @DataBoundSetter
+    public void setReuseNode(boolean reuseNode) {
+        this.reuseNode = reuseNode;
+    }
+
+    public @CheckForNull
+    String getLabel() {
+        return label;
+    }
+
+    @DataBoundSetter
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public @CheckForNull String getCustomWorkspace() {
+        return customWorkspace;
+    }
+
+    @DataBoundSetter
+    public void setCustomWorkspace(String customWorkspace) {
+        this.customWorkspace = customWorkspace;
+    }
+
+    public @CheckForNull String getArgs() {
+        return args;
+    }
+
+    @DataBoundSetter
+    public void setArgs(String args) {
+        this.args = args;
+    }
+
+    public boolean isContainerPerStageRoot() {
+        return containerPerStageRoot;
+    }
+
+    @DataBoundSetter
+    public void setContainerPerStageRoot(boolean containerPerStageRoot) {
+        this.containerPerStageRoot = containerPerStageRoot;
+    }
+
+    @Override
+    public void initialize(Map<String, DeclarativeOption> options, boolean explicitAgentInStage) {
+        if (options.get(ContainerPerStage.SYMBOL) != null) {
+            if (!inStage) {
+                containerPerStageRoot = true;
+            } else if (!explicitAgentInStage) {
+                reuseNode = true;
+            }
+        }
+    }
+
+    @Override
+    public boolean useRootAgent(Map<String, DeclarativeOption> options) {
+        return options.get(ContainerPerStage.SYMBOL) != null;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/ContainerPerStage.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/ContainerPerStage.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import hudson.Extension;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption;
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOptionDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class ContainerPerStage extends DeclarativeOption {
+
+    @DataBoundConstructor
+    public ContainerPerStage() {}
+
+    public static final String SYMBOL = "newContainerPerStage";
+
+    @Extension @Symbol(SYMBOL)
+    public static class DescriptorImpl extends DeclarativeOptionDescriptor {
+
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtils.java
@@ -1,0 +1,147 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import hudson.model.Run;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.docker.workflow.declarative.DockerPropertiesProvider;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
+import org.jenkinsci.plugins.workflow.cps.CpsThread;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * @see org.jenkinsci.plugins.docker.workflow.declarative.DockerLabelProvider
+ */
+public class DeclarativeDockerUtils {
+    private static final String DEFAULT_REGISTRY = "https://index.docker.io/v1/";
+
+    private static Run<?,?> currentRun() {
+        try {
+            CpsThread t = CpsThread.current();
+            if (t != null) {
+                CpsFlowExecution e = t.getExecution();
+                if (e != null) {
+                    FlowExecutionOwner o = e.getOwner();
+                    if (o != null && o.getExecutable() instanceof Run) {
+                        return (Run)o.getExecutable();
+                    }
+                }
+            }
+
+            return null;
+        } catch (IOException i) {
+            return null;
+        }
+    }
+
+    @Whitelisted
+    public static String getLabel() {
+        return getLabel(null);
+    }
+
+    @Whitelisted
+    public static String getLabel(@Nullable String override) {
+        if (!StringUtils.isBlank(override)) {
+            return override;
+        } else {
+            Run<?,?> r = currentRun();
+            for (DockerPropertiesProvider provider : DockerPropertiesProvider.all()) {
+                String label = provider.getLabel(r);
+                if (!StringUtils.isBlank(label)) {
+                    return label;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Whitelisted
+    public static String getRegistryUrl() {
+        return getRegistryUrl(null);
+    }
+
+    @Whitelisted
+    public static String getRegistryUrl(@Nullable String override) {
+        if (!StringUtils.isBlank(override)) {
+            return override;
+        } else {
+            Run<?,?> r = currentRun();
+            for (DockerPropertiesProvider provider : DockerPropertiesProvider.all()) {
+                String url = provider.getRegistryUrl(r);
+                if (!StringUtils.isBlank(url)) {
+                    return url;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Whitelisted
+    public static String getRegistryCredentialsId() {
+        return getRegistryCredentialsId(null);
+    }
+
+    @Whitelisted
+    public static String getRegistryCredentialsId(@Nullable String override) {
+        if (!StringUtils.isBlank(override)) {
+            return override;
+        } else {
+            Run<?,?> r = currentRun();
+            for (DockerPropertiesProvider provider : DockerPropertiesProvider.all()) {
+                String id = provider.getRegistryCredentialsId(r);
+                if (!StringUtils.isBlank(id)) {
+                    return id;
+                }
+            }
+            return null;
+        }
+    }
+    public static class DockerRegistry implements Serializable {
+        public String registry;
+        public String credential;
+
+        public DockerRegistry(String registry, String creds){
+            if (registry != null) {
+                this.registry = registry;
+            } else {
+                this.registry = DEFAULT_REGISTRY;
+            }
+            this.credential = creds;
+        }
+
+        public boolean hasData(){
+            return credential != null || !registry.equals(DEFAULT_REGISTRY);
+        }
+
+        public static DockerRegistry build(String dockerHub, String creds){
+            return new DockerRegistry( getRegistryUrl(dockerHub), getRegistryCredentialsId(creds));
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerLabelProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerLabelProvider.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.Run;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * Provider of label expressions to use for {@code agent: docker} when no other label is provided.
+ */
+public abstract class DockerLabelProvider implements ExtensionPoint {
+
+    @CheckForNull
+    public abstract String getLabel(Run run);
+
+    public static ExtensionList<DockerLabelProvider> all() {
+        return ExtensionList.lookup(DockerLabelProvider.class);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipeline.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipeline.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import hudson.Extension;
+import hudson.Util;
+import hudson.util.FormValidation;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.docker.workflow.declarative.AbstractDockerAgent;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.annotation.Nonnull;
+
+public class DockerPipeline extends AbstractDockerAgent<DockerPipeline> {
+    private String image;
+    private boolean alwaysPull;
+
+    @DataBoundConstructor
+    public DockerPipeline(@Nonnull String image) {
+        this.image = image;
+    }
+
+    public @Nonnull String getImage() {
+        return image;
+    }
+
+    @DataBoundSetter
+    public void setAlwaysPull(boolean alwaysPull) {
+        this.alwaysPull = alwaysPull;
+    }
+
+    public boolean isAlwaysPull() {
+        return alwaysPull;
+    }
+
+    @Extension(ordinal = 1000) @Symbol("docker")
+    public static class DescriptorImpl extends DeclarativeAgentDescriptor<DockerPipeline> {
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return "Run inside a Docker container";
+        }
+
+        public FormValidation doCheckImage(@QueryParameter String image) {
+            if (StringUtils.isEmpty(Util.fixEmptyAndTrim(image))) {
+                return FormValidation.error("Image is required.");
+            } else {
+                return FormValidation.ok();
+            }
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfile.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfile.java
@@ -1,0 +1,115 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import hudson.Extension;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.docker.workflow.declarative.AbstractDockerAgent;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+
+public class DockerPipelineFromDockerfile extends AbstractDockerAgent<DockerPipelineFromDockerfile> {
+    private String filename;
+    private String dir;
+    private String additionalBuildArgs;
+
+    @DataBoundConstructor
+    public DockerPipelineFromDockerfile() {
+    }
+
+    public Object getFilename() {
+        return filename;
+    }
+
+    @DataBoundSetter
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+
+    public String getDir() {
+        return dir;
+    }
+
+    @DataBoundSetter
+    public void setDir(String dir) {
+        this.dir = dir;
+    }
+
+    public String getAdditionalBuildArgs() {
+        return additionalBuildArgs;
+    }
+
+    @DataBoundSetter
+    public void setAdditionalBuildArgs(String additionalBuildArgs) {
+        this.additionalBuildArgs = additionalBuildArgs;
+    }
+
+    @Nonnull
+    public String getActualDir() {
+        if (!StringUtils.isEmpty(dir)) {
+            return dir;
+        } else {
+            return ".";
+        }
+    }
+
+    @Nonnull
+    public String getDockerfilePath(boolean isUnix) {
+        StringBuilder fullPath = new StringBuilder();
+        if (!StringUtils.isEmpty(dir)) {
+            fullPath.append(dir);
+            if (isUnix) {
+                fullPath.append(IOUtils.DIR_SEPARATOR_UNIX);
+            } else {
+                fullPath.append(IOUtils.DIR_SEPARATOR_WINDOWS);
+            }
+        }
+        fullPath.append(getDockerfileAsString());
+        return fullPath.toString();
+    }
+
+    @Nonnull
+    public String getDockerfileAsString() {
+        if (filename != null) {
+            return filename;
+        } else {
+            return "Dockerfile";
+        }
+    }
+
+    @Extension(ordinal = 999) @Symbol("dockerfile")
+    public static class DescriptorImpl extends DeclarativeAgentDescriptor<DockerPipelineFromDockerfile> {
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return "Build a Dockerfile and run in a container using that image";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerPropertiesProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerPropertiesProvider.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.Run;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+
+/**
+ * Provider of configuration options to use for {@code agent docker}.
+ */
+public abstract class DockerPropertiesProvider implements ExtensionPoint {
+
+    @CheckForNull
+    public abstract String getRegistryUrl(@Nullable Run run);
+
+    @CheckForNull
+    public abstract String getRegistryCredentialsId(@Nullable Run run);
+
+    @CheckForNull
+    public abstract String getLabel(@Nullable Run run);
+
+    public static ExtensionList<DockerPropertiesProvider> all() {
+        return ExtensionList.lookup(DockerPropertiesProvider.class);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/ExtensionFilterImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/ExtensionFilterImpl.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import hudson.Extension;
+import hudson.ExtensionComponent;
+import jenkins.ExtensionFilter;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+
+/**
+ * Temporary trick to ensure that there are not two copies of the agent types.
+ */
+@Extension
+public class ExtensionFilterImpl extends ExtensionFilter {
+
+    @Override
+    public <T> boolean allows(Class<T> type, ExtensionComponent<T> component) {
+        if (type == DeclarativeAgentDescriptor.class) {
+            switch (component.getInstance().getClass().getName()) {
+            case "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.DockerPipeline$DescriptorImpl":
+            case "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.DockerPipelineFromDockerfile$DescriptorImpl":
+                return false;
+            default:
+                // OK
+            }
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/FolderConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/FolderConfig.java
@@ -1,0 +1,183 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
+import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.Run;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Provides folder level configuration.
+ */
+public class FolderConfig extends AbstractFolderProperty<AbstractFolder<?>> {
+    private String dockerLabel;
+    private DockerRegistryEndpoint registry;
+
+    @DataBoundConstructor
+    public FolderConfig() {
+    }
+
+    /**
+     * For testing
+     *
+     * @param dockerLabel the docker label to use
+     * @param url The registry URL
+     * @param creds the registry credentials ID
+     */
+    public FolderConfig(String dockerLabel, String url, String creds) {
+        this.dockerLabel = dockerLabel;
+        this.registry = new DockerRegistryEndpoint(url, creds);
+    }
+
+    public String getDockerLabel() {
+        return dockerLabel;
+    }
+
+    @DataBoundSetter
+    public void setDockerLabel(String dockerLabel) {
+        this.dockerLabel = dockerLabel;
+    }
+
+    public DockerRegistryEndpoint getRegistry() {
+        return registry;
+    }
+
+    @DataBoundSetter
+    public void setRegistry(DockerRegistryEndpoint registry) {
+        this.registry = registry;
+    }
+
+    @Extension @Symbol({"pipeline-model-docker", "pipeline-model"})
+    public static class DescriptorImpl extends AbstractFolderPropertyDescriptor {
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return Messages.PipelineModelDefinition_DisplayName();
+        }
+    }
+
+    @Extension(ordinal = 10000) //First to be asked
+    public static class FolderDockerPropertiesProvider extends DockerPropertiesProvider {
+
+        @Override
+        public String getLabel(@Nullable Run run) {
+            if (run != null) {
+                Job job = run.getParent();
+                ItemGroup parent = job.getParent();
+                while (parent != null) {
+
+                    if (parent instanceof AbstractFolder) {
+                        AbstractFolder folder = (AbstractFolder) parent;
+                        FolderConfig config = (FolderConfig) folder.getProperties().get(FolderConfig.class);
+                        if (config != null) {
+                            String label = config.getDockerLabel();
+                            if (!StringUtils.isBlank(label)) {
+                                return label;
+                            }
+                        }
+                    }
+
+                    if (parent instanceof Item) {
+                        parent = ((Item) parent).getParent();
+                    } else {
+                        parent = null;
+                    }
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public String getRegistryUrl(@Nullable Run run) {
+            if (run != null) {
+                Job job = run.getParent();
+                ItemGroup parent = job.getParent();
+                while (parent != null) {
+
+                    if (parent instanceof AbstractFolder) {
+                        AbstractFolder folder = (AbstractFolder) parent;
+                        FolderConfig config = (FolderConfig) folder.getProperties().get(FolderConfig.class);
+                        if (config != null) {
+                            DockerRegistryEndpoint registry = config.getRegistry();
+                            if (registry != null && !StringUtils.isBlank(registry.getUrl())) {
+                                return registry.getUrl();
+                            }
+                        }
+                    }
+
+                    if (parent instanceof Item) {
+                        parent = ((Item) parent).getParent();
+                    } else {
+                        parent = null;
+                    }
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public String getRegistryCredentialsId(@Nullable Run run) {
+            if (run != null) {
+                Job job = run.getParent();
+                ItemGroup parent = job.getParent();
+                while (parent != null) {
+
+                    if (parent instanceof AbstractFolder) {
+                        AbstractFolder folder = (AbstractFolder) parent;
+                        FolderConfig config = (FolderConfig) folder.getProperties().get(FolderConfig.class);
+                        if (config != null) {
+                            DockerRegistryEndpoint registry = config.getRegistry();
+                            if (registry != null && !StringUtils.isBlank(registry.getCredentialsId())) {
+                                return registry.getCredentialsId();
+                            }
+                        }
+                    }
+
+                    if (parent instanceof Item) {
+                        parent = ((Item) parent).getParent();
+                    } else {
+                        parent = null;
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import com.google.inject.Inject;
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.Util;
+import hudson.model.Run;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.Nullable;
+
+/**
+ * The system config.
+ *
+ * For example the system level {@link DockerLabelProvider}.
+ */
+@Extension @Symbol({"pipeline-model-docker", "pipeline-model"})
+public class GlobalConfig extends GlobalConfiguration {
+    private String dockerLabel;
+    private DockerRegistryEndpoint registry;
+
+    public GlobalConfig() {
+        load();
+    }
+
+    public String getDockerLabel() {
+        return Util.fixEmpty(dockerLabel);
+    }
+
+    @DataBoundSetter
+    public void setDockerLabel(String dockerLabel) {
+        this.dockerLabel = dockerLabel;
+    }
+
+    public DockerRegistryEndpoint getRegistry() {
+        return registry;
+    }
+
+    @DataBoundSetter
+    public void setRegistry(DockerRegistryEndpoint registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        req.bindJSON(this, json);
+        save();
+        return true;
+    }
+
+    public static GlobalConfig get() {
+        return ExtensionList.lookup(GlobalConfiguration.class).get(GlobalConfig.class);
+    }
+
+    @Extension(ordinal = -10000) //Last one to be asked
+    public static final class GlobalConfigDockerPropertiesProvider extends DockerPropertiesProvider {
+        @Inject
+        GlobalConfig config;
+
+        @Override
+        public String getLabel(@Nullable Run run) {
+            return config.getDockerLabel();
+        }
+
+        @Override
+        public String getRegistryUrl(@Nullable Run run) {
+            if (config.getRegistry() != null && !StringUtils.isBlank(config.getRegistry().getUrl())) {
+                return config.getRegistry().getUrl();
+            } else {
+                return null;
+            }
+        }
+
+        @Override
+        public String getRegistryCredentialsId(@Nullable Run run) {
+            if (config.getRegistry() != null && !StringUtils.isBlank(config.getRegistry().getCredentialsId())) {
+                return config.getRegistry().getCredentialsId();
+            } else {
+                return null;
+            }
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent/help-args.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent/help-args.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    Additional arguments to pass to <code>docker run ...</code>
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent/help-customWorkspace.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent/help-customWorkspace.html
@@ -1,0 +1,28 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    If specified, this will be used as the custom workspace on the agent the Docker container will be run on, underneath
+    the workspace root on that agent.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent/help-label.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent/help-label.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    The label for the agent to run the Docker container on.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent/help-registryCredentialsId.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent/help-registryCredentialsId.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    Optional credentials ID for the Docker registry specified in <code>registryUrl</code>.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent/help-registryUrl.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent/help-registryUrl.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    Optional URL for a Docker registry to use when pulling images.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent/help-reuseNode.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent/help-reuseNode.html
@@ -1,0 +1,28 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    If true, run the Docker container on the agent specified at the top level of the Pipeline. Has no effect when
+    specified on the top level agent.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerPipelineScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerPipelineScript.groovy
@@ -1,0 +1,79 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
+
+import hudson.FilePath
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.AbstractDockerAgent
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeDockerUtils
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+abstract class AbstractDockerPipelineScript<A extends AbstractDockerAgent<A>> extends DeclarativeAgentScript<A> {
+
+    AbstractDockerPipelineScript(CpsScript s, A a) {
+        super(s, a)
+    }
+
+    @Override
+    Closure run(Closure body) {
+        if (describable.reuseNode && script.getContext(FilePath.class) != null) {
+            return {
+                configureRegistry(body).call()
+            }
+        } else if (describable.containerPerStageRoot) {
+            return getLabelScript().run {
+                body.call()
+            }
+        } else {
+            return getLabelScript().run {
+                configureRegistry(body).call()
+            }
+        }
+    }
+
+    protected LabelScript getLabelScript() {
+        String targetLabel = DeclarativeDockerUtils.getLabel(describable.label)
+        Label l = (Label) Label.DescriptorImpl.instanceForName("label", [label: targetLabel])
+        l.copyFlags(describable)
+        l.customWorkspace = describable.customWorkspace
+        return (LabelScript) l.getScript(script)
+    }
+
+    protected Closure configureRegistry(Closure body) {
+        return {
+            DeclarativeDockerUtils.DockerRegistry registry = DeclarativeDockerUtils.DockerRegistry.build(describable.registryUrl, describable.registryCredentialsId)
+            if (registry.hasData()) {
+                script.getProperty("docker").withRegistry(registry.registry, registry.credential) {
+                    runImage(body).call()
+                }
+            } else {
+                runImage(body).call()
+            }
+        }
+    }
+
+    protected abstract Closure runImage(Closure body)
+}

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerPipelineScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerPipelineScript.groovy
@@ -23,12 +23,11 @@
  */
 
 
-package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
+package org.jenkinsci.plugins.docker.workflow.declarative
 
 import hudson.FilePath
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.AbstractDockerAgent
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeDockerUtils
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 abstract class AbstractDockerPipelineScript<A extends AbstractDockerAgent<A>> extends DeclarativeAgentScript<A> {

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerPipelineScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerPipelineScript.groovy
@@ -55,6 +55,7 @@ abstract class AbstractDockerPipelineScript<A extends AbstractDockerAgent<A>> ex
 
     protected DeclarativeAgentScript getLabelScript() {
         String targetLabel = DeclarativeDockerUtils.getLabel(describable.label)
+        // TODO revert reflection in daad17b90ed0 when we can depend directly on pipeline-model-definition
         def l = Jenkins.get().getDescriptorByName('org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.Label').instanceForName("label", [label: targetLabel])
         l.copyFlags(describable)
         l.customWorkspace = describable.customWorkspace

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerPipelineScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerPipelineScript.groovy
@@ -26,7 +26,7 @@
 package org.jenkinsci.plugins.docker.workflow.declarative
 
 import hudson.FilePath
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.AbstractDockerAgent
+import jenkins.model.Jenkins
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
@@ -53,12 +53,12 @@ abstract class AbstractDockerPipelineScript<A extends AbstractDockerAgent<A>> ex
         }
     }
 
-    protected LabelScript getLabelScript() {
+    protected DeclarativeAgentScript getLabelScript() {
         String targetLabel = DeclarativeDockerUtils.getLabel(describable.label)
-        Label l = (Label) Label.DescriptorImpl.instanceForName("label", [label: targetLabel])
+        def l = Jenkins.get().getDescriptorByName('org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.Label').instanceForName("label", [label: targetLabel])
         l.copyFlags(describable)
         l.customWorkspace = describable.customWorkspace
-        return (LabelScript) l.getScript(script)
+        return (DeclarativeAgentScript) l.getScript(script)
     }
 
     protected Closure configureRegistry(Closure body) {

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/ContainerPerStage/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/ContainerPerStage/config.jelly
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2018, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/ContainerPerStage/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/ContainerPerStage/help.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2018, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    If specified, any stage using the top-level Docker or Dockerfile agent will get a new container on the same node.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipeline/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipeline/config.jelly
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2018, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="image" title="Image">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="args" title="Additional arguments">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="label" title="Label">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="reuseNode">
+        <f:checkbox title="Reuse Node"/>
+    </f:entry>
+    <f:entry field="customWorkspace" title="Custom Workspace">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="registryUrl" title="Registry URL">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="registryCredentialsId" title="Registry Credentials ID">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="alwaysPull">
+        <f:checkbox title="Always Pull Image"/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipeline/help-alwaysPull.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipeline/help-alwaysPull.html
@@ -1,0 +1,28 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    If true, <code>docker pull ...</code> will always be run, even if the image tag is already present. This is useful
+    in cases such as if the latest tag has been moved.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipeline/help-image.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipeline/help-image.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    The Docker image to use.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipeline/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipeline/help.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    The job or stage will run within a Docker container.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfile/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfile/config.jelly
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2018, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="filename" title="Filename">
+        <f:textbox default="Dockerfile" />
+    </f:entry>
+    <f:entry field="dir" title="Directory">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="additionalBuildArgs" title="Additional Docker build arguments">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="args" title="Additional arguments">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="label" title="Label">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="reuseNode">
+        <f:checkbox title="Reuse Node"/>
+    </f:entry>
+    <f:entry field="customWorkspace" title="Custom Workspace">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="registryUrl" title="Registry URL">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="registryCredentialsId" title="Registry Credentials ID">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfile/help-additionalBuildArgs.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfile/help-additionalBuildArgs.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    Optional additional arguments to pass to <code>docker build</code>.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfile/help-dir.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfile/help-dir.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    The directory to run <code>docker build ...</code> from. Defaults to the workspace root.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfile/help-filename.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfile/help-filename.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    The filename to pass to <code>docker build ...</code>. Defaults to <code>Dockerfile</code>.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfile/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfile/help.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    The job or stage will be run in a Docker container using an image built from a <code>Dockerfile</code>.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfileScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfileScript.groovy
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.SyntheticStageNames
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
+
+class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineScript<DockerPipelineFromDockerfile> {
+
+    DockerPipelineFromDockerfileScript(CpsScript s, DockerPipelineFromDockerfile a) {
+        super(s, a)
+    }
+
+    @Override
+    Closure runImage(Closure body) {
+        return {
+            def img = null
+            if (!Utils.withinAStage()) {
+                script.stage(SyntheticStageNames.agentSetup()) {
+                    try {
+                        img = buildImage().call()
+                    } catch (Exception e) {
+                        Utils.markStageFailedAndContinued(SyntheticStageNames.agentSetup())
+                        throw e
+                    }
+                }
+            } else {
+                img = buildImage().call()
+            }
+            if (img != null) {
+                img.inside(describable.args, {
+                    body.call()
+                })
+            }
+        }
+    }
+
+    private Closure buildImage() {
+        return {
+            boolean isUnix = script.isUnix()
+            def dockerfilePath = describable.getDockerfilePath(isUnix)
+            try {
+                RunWrapper runWrapper = (RunWrapper)script.getProperty("currentBuild")
+                def additionalBuildArgs = describable.getAdditionalBuildArgs() ? " ${describable.additionalBuildArgs}" : ""
+                def hash = Utils.stringToSHA1("${runWrapper.fullProjectName}\n${script.readFile("${dockerfilePath}")}\n${additionalBuildArgs}")
+                def imgName = "${hash}"
+                def commandLine = "docker build -t ${imgName}${additionalBuildArgs} -f \"${dockerfilePath}\" \"${describable.getActualDir()}\""
+                if (isUnix)
+                    script.sh commandLine
+                else
+                    script.bat commandLine
+
+                return script.getProperty("docker").image(imgName)
+            } catch (FileNotFoundException f) {
+                script.error("No Dockerfile found at ${dockerfilePath} in repository - failing.")
+                return null
+            }
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfileScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfileScript.groovy
@@ -25,12 +25,14 @@
 
 package org.jenkinsci.plugins.docker.workflow.declarative
 
+import jenkins.model.Jenkins
 import org.jenkinsci.plugins.pipeline.modeldefinition.SyntheticStageNames
-import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
 class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineScript<DockerPipelineFromDockerfile> {
+
+    static Class Utils = Jenkins.get().pluginManager.getPlugin('pipeline-model-definition').classLoader.loadClass('org.jenkinsci.plugins.pipeline.modeldefinition.Utils')
 
     DockerPipelineFromDockerfileScript(CpsScript s, DockerPipelineFromDockerfile a) {
         super(s, a)

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfileScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfileScript.groovy
@@ -32,6 +32,7 @@ import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
 class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineScript<DockerPipelineFromDockerfile> {
 
+    // TODO revert reflection in daad17b90ed0 when we can depend directly on pipeline-model-definition
     static Class Utils = Jenkins.get().pluginManager.getPlugin('pipeline-model-definition').classLoader.loadClass('org.jenkinsci.plugins.pipeline.modeldefinition.Utils')
 
     DockerPipelineFromDockerfileScript(CpsScript s, DockerPipelineFromDockerfile a) {

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfileScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfileScript.groovy
@@ -23,7 +23,7 @@
  */
 
 
-package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
+package org.jenkinsci.plugins.docker.workflow.declarative
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.SyntheticStageNames
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineScript.groovy
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.SyntheticStageNames
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+class DockerPipelineScript extends AbstractDockerPipelineScript<DockerPipeline> {
+
+    DockerPipelineScript(CpsScript s, DockerPipeline a) {
+        super(s, a)
+    }
+
+    @Override
+    Closure runImage(Closure body) {
+        return {
+            if (!Utils.withinAStage() && describable.alwaysPull) {
+                script.stage(SyntheticStageNames.agentSetup()) {
+                    try {
+                        script.getProperty("docker").image(describable.image).pull()
+                    } catch (Exception e) {
+                        Utils.markStageFailedAndContinued(SyntheticStageNames.agentSetup())
+                        throw e
+                    }
+                }
+            }
+            if (Utils.withinAStage() && describable.alwaysPull) {
+                script.getProperty("docker").image(describable.image).pull()
+            }
+            script.getProperty("docker").image(describable.image).inside(describable.args, {
+                body.call()
+            })
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineScript.groovy
@@ -25,11 +25,13 @@
 
 package org.jenkinsci.plugins.docker.workflow.declarative
 
+import jenkins.model.Jenkins
 import org.jenkinsci.plugins.pipeline.modeldefinition.SyntheticStageNames
-import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 class DockerPipelineScript extends AbstractDockerPipelineScript<DockerPipeline> {
+
+    static Class Utils = Jenkins.get().pluginManager.getPlugin('pipeline-model-definition').classLoader.loadClass('org.jenkinsci.plugins.pipeline.modeldefinition.Utils')
 
     DockerPipelineScript(CpsScript s, DockerPipeline a) {
         super(s, a)

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineScript.groovy
@@ -23,7 +23,7 @@
  */
 
 
-package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
+package org.jenkinsci.plugins.docker.workflow.declarative
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.SyntheticStageNames
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineScript.groovy
@@ -31,6 +31,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 class DockerPipelineScript extends AbstractDockerPipelineScript<DockerPipeline> {
 
+    // TODO revert reflection in daad17b90ed0 when we can depend directly on pipeline-model-definition
     static Class Utils = Jenkins.get().pluginManager.getPlugin('pipeline-model-definition').classLoader.loadClass('org.jenkinsci.plugins.pipeline.modeldefinition.Utils')
 
     DockerPipelineScript(CpsScript s, DockerPipeline a) {

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/FolderConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/FolderConfig/config.groovy
@@ -23,7 +23,7 @@
  *
  */
 
-package org.jenkinsci.plugins.pipeline.modeldefinition.config.FolderConfig
+package org.jenkinsci.plugins.docker.workflow.declarative.FolderConfig
 
 
 def f = namespace(lib.FormTagLib)

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/FolderConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/FolderConfig/config.groovy
@@ -1,0 +1,36 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.config.FolderConfig
+
+
+def f = namespace(lib.FormTagLib)
+
+f.section(title:_("Declarative Pipeline (Docker)")) {
+    f.entry(field: "dockerLabel", title: _("Docker Label")) {
+        f.textbox()
+    }
+    f.property(field: "registry")
+}

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/FolderConfig/help-dockerLabel.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/FolderConfig/help-dockerLabel.html
@@ -1,0 +1,31 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2016, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  ~
+  -->
+
+<p>
+    The label expression to use when a pipeline runs with
+    <code>agent { docker ... }</code> or <code>agent { dockerfile ... }</code>
+    and no explicit label is provided. Leave empty to
+    delegate to parent or system config.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig/config.groovy
@@ -1,0 +1,36 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.config.GlobalConfig
+
+
+def f = namespace(lib.FormTagLib)
+
+f.section(title:_("Declarative Pipeline (Docker)")) {
+    f.entry(field: "dockerLabel", title:_("Docker Label")) {
+        f.textbox()
+    }
+    f.property(field: "registry")
+}

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig/config.groovy
@@ -23,7 +23,7 @@
  *
  */
 
-package org.jenkinsci.plugins.pipeline.modeldefinition.config.GlobalConfig
+package org.jenkinsci.plugins.docker.workflow.declarative.GlobalConfig
 
 
 def f = namespace(lib.FormTagLib)

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig/help-dockerLabel.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig/help-dockerLabel.html
@@ -1,0 +1,31 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2016, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  ~
+  -->
+
+<p>
+    The label expression to use when a pipeline runs with
+    <code>agent { docker ... }</code> or <code>agent { dockerfile ... }</code>
+    and no explicit label is provided. Leave empty to
+    delegate to parent or system config.
+</p>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/Messages.properties
@@ -1,0 +1,2 @@
+PipelineModelDefinition.DisplayName=Declarative Pipeline (Docker)
+ModelValidatorImpl.DirSeparatorInDockerfileName=Dockerfile filename cannot contain directory separators.

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtilsTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.jenkinsci.plugins.docker.workflow.DockerTestUtil.assumeDocker;
 import static org.junit.Assert.assertThat;
 
 /**

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtilsTest.java
@@ -67,7 +67,7 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
     public void plainSystemConfig() throws Exception {
         GlobalConfig.get().setDockerLabel("config_docker");
         GlobalConfig.get().setRegistry(new DockerRegistryEndpoint("https://docker.registry", globalCred.getId()));
-        expect("declarativeDockerConfig")
+        expect("org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig")
                 .logContains("Docker Label is: config_docker",
                         "Registry URL is: https://docker.registry",
                         "Registry Creds ID is: " + globalCred.getId()).go();
@@ -86,7 +86,7 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
         Folder folder = j.createProject(Folder.class);
         getFolderStore(folder).addCredentials(Domain.global(), folderCred);
         folder.addProperty(new FolderConfig("folder_docker", "https://folder.registry", folderCred.getId()));
-        expect("declarativeDockerConfig")
+        expect("org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig")
                 .inFolder(folder)
                 .runFromRepo(false)
                 .logContains("Docker Label is: folder_docker",
@@ -100,7 +100,7 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
         getFolderStore(folder).addCredentials(Domain.global(), folderCred);
         getFolderStore(folder).addCredentials(Domain.global(), grandParentCred);
         folder.addProperty(new FolderConfig("folder_docker", "https://folder.registry", folderCred.getId()));
-        expect("declarativeDockerConfigWithOverride")
+        expect("org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfigWithOverride")
                 .inFolder(folder)
                 .runFromRepo(false)
                 .logContains("Docker Label is: other-label",
@@ -115,7 +115,7 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
         Folder folder = j.createProject(Folder.class);
         getFolderStore(folder).addCredentials(Domain.global(), folderCred);
         folder.addProperty(new FolderConfig("folder_docker", "https://folder.registry", folderCred.getId()));
-        expect("declarativeDockerConfig")
+        expect("org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig")
                 .inFolder(folder)
                 .runFromRepo(false)
                 .logContains("Docker Label is: folder_docker",
@@ -132,7 +132,7 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
         getFolderStore(grandParent).addCredentials(Domain.global(), grandParentCred);
         grandParent.addProperty(new FolderConfig("parent_docker", "https://parent.registry", grandParentCred.getId()));
         Folder parent = grandParent.createProject(Folder.class, "testParent"); //Can be static since grandParent should be unique
-        expect("declarativeDockerConfig")
+        expect("org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig")
                 .inFolder(parent)
                 .runFromRepo(false)
                 .logContains("Docker Label is: parent_docker",
@@ -149,7 +149,7 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
         getFolderStore(parent).addCredentials(Domain.global(), folderCred);
         parent.addProperty(new FolderConfig("folder_docker", "https://folder.registry", folderCred.getId()));
 
-        expect("declarativeDockerConfig")
+        expect("org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig")
                 .inFolder(parent)
                 .runFromRepo(false)
                 .logContains("Docker Label is: folder_docker",
@@ -172,7 +172,7 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
         GlobalConfig.get().setDockerLabel("thisone");
         GlobalConfig.get().setRegistry(null);
 
-        expect("agent/agentDockerEnvTest").runFromRepo(false).logContains("Running on assumed Docker agent").go();
+        expect("org/jenkinsci/plugins/docker/workflow/declarative/agentDockerEnvTest").runFromRepo(false).logContains("Running on assumed Docker agent").go();
 
     }
 
@@ -188,7 +188,7 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
         GlobalConfig.get().setDockerLabel("thisone");
         GlobalConfig.get().setRegistry(null);
 
-        expect("agent/agentDockerEnvSpecLabel").runFromRepo(false).logContains("Running on assumed Docker agent").go();
+        expect("org/jenkinsci/plugins/docker/workflow/declarative/agentDockerEnvSpecLabel").runFromRepo(false).logContains("Running on assumed Docker agent").go();
 
     }
 

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtilsTest.java
@@ -34,13 +34,13 @@ import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.ExtensionList;
 import hudson.model.Slave;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
+import org.jenkinsci.plugins.docker.workflow.DockerTestUtil;
 import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.jenkinsci.plugins.docker.workflow.DockerTestUtil.assumeDocker;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -162,7 +162,7 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
 
     @Test
     public void runsOnCorrectSlave() throws Exception {
-        assumeDocker();
+        DockerTestUtil.assumeDocker();
         Slave s = j.createOnlineSlave();
         s.setLabelString("notthis");
         env(s).put("DOCKER_INDICATOR", "WRONG").set();
@@ -178,7 +178,7 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
 
     @Test
     public void runsOnSpecifiedSlave() throws Exception {
-        assumeDocker();
+        DockerTestUtil.assumeDocker();
         Slave s = j.createOnlineSlave();
         s.setLabelString("thisspec");
         env(s).put("DOCKER_INDICATOR", "SPECIFIED").set();

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtilsTest.java
@@ -1,0 +1,207 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.ExtensionList;
+import hudson.model.Slave;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
+import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests {@link DeclarativeDockerUtils}.
+ *
+ * And related configurations like {@link DockerPropertiesProvider}.
+ */
+public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
+    private static final UsernamePasswordCredentialsImpl globalCred = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL,
+            "globalCreds", "sample", "bobby", "s3cr37");
+    private static final UsernamePasswordCredentialsImpl folderCred = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL,
+            "folderCreds", "other sample", "andrew", "s0mething");
+    private static final UsernamePasswordCredentialsImpl grandParentCred = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL,
+            "grandParentCreds", "yet another sample", "leopold", "idunno");
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        CredentialsStore store = CredentialsProvider.lookupStores(j.jenkins).iterator().next();
+
+        store.addCredentials(Domain.global(), globalCred);
+    }
+
+    @Test
+    public void plainSystemConfig() throws Exception {
+        GlobalConfig.get().setDockerLabel("config_docker");
+        GlobalConfig.get().setRegistry(new DockerRegistryEndpoint("https://docker.registry", globalCred.getId()));
+        expect("declarativeDockerConfig")
+                .logContains("Docker Label is: config_docker",
+                        "Registry URL is: https://docker.registry",
+                        "Registry Creds ID is: " + globalCred.getId()).go();
+    }
+
+    @Test
+    public void testExtensionOrdinal() {
+        ExtensionList<DockerPropertiesProvider> all = DockerPropertiesProvider.all();
+        assertThat(all, hasSize(2));
+        assertThat(all.get(0), instanceOf(FolderConfig.FolderDockerPropertiesProvider.class));
+        assertThat(all.get(1), instanceOf(GlobalConfig.GlobalConfigDockerPropertiesProvider.class));
+    }
+
+    @Test
+    public void directParent() throws Exception {
+        Folder folder = j.createProject(Folder.class);
+        getFolderStore(folder).addCredentials(Domain.global(), folderCred);
+        folder.addProperty(new FolderConfig("folder_docker", "https://folder.registry", folderCred.getId()));
+        expect("declarativeDockerConfig")
+                .inFolder(folder)
+                .runFromRepo(false)
+                .logContains("Docker Label is: folder_docker",
+                        "Registry URL is: https://folder.registry",
+                        "Registry Creds ID is: " + folderCred.getId()).go();
+    }
+
+    @Test
+    public void withDefaults() throws Exception {
+        Folder folder = j.createProject(Folder.class);
+        getFolderStore(folder).addCredentials(Domain.global(), folderCred);
+        getFolderStore(folder).addCredentials(Domain.global(), grandParentCred);
+        folder.addProperty(new FolderConfig("folder_docker", "https://folder.registry", folderCred.getId()));
+        expect("declarativeDockerConfigWithOverride")
+                .inFolder(folder)
+                .runFromRepo(false)
+                .logContains("Docker Label is: other-label",
+                        "Registry URL is: https://other.registry",
+                        "Registry Creds ID is: " + grandParentCred.getId()).go();
+    }
+
+    @Test
+    public void directParentNotSystem() throws Exception {
+        GlobalConfig.get().setDockerLabel("config_docker");
+        GlobalConfig.get().setRegistry(new DockerRegistryEndpoint("https://docker.registry", globalCred.getId()));
+        Folder folder = j.createProject(Folder.class);
+        getFolderStore(folder).addCredentials(Domain.global(), folderCred);
+        folder.addProperty(new FolderConfig("folder_docker", "https://folder.registry", folderCred.getId()));
+        expect("declarativeDockerConfig")
+                .inFolder(folder)
+                .runFromRepo(false)
+                .logContains("Docker Label is: folder_docker",
+                        "Registry URL is: https://folder.registry",
+                        "Registry Creds ID is: " + folderCred.getId())
+                .logNotContains("Docker Label is: config_docker",
+                        "Registry URL is: https://docker.registry",
+                        "Registry Creds ID is: " + globalCred.getId()).go();
+    }
+
+    @Test
+    public void grandParent() throws Exception {
+        Folder grandParent = j.createProject(Folder.class);
+        getFolderStore(grandParent).addCredentials(Domain.global(), grandParentCred);
+        grandParent.addProperty(new FolderConfig("parent_docker", "https://parent.registry", grandParentCred.getId()));
+        Folder parent = grandParent.createProject(Folder.class, "testParent"); //Can be static since grandParent should be unique
+        expect("declarativeDockerConfig")
+                .inFolder(parent)
+                .runFromRepo(false)
+                .logContains("Docker Label is: parent_docker",
+                        "Registry URL is: https://parent.registry",
+                        "Registry Creds ID is: " + grandParentCred.getId()).go();
+    }
+
+    @Test
+    public void grandParentOverride() throws Exception {
+        Folder grandParent = j.createProject(Folder.class);
+        getFolderStore(grandParent).addCredentials(Domain.global(), grandParentCred);
+        grandParent.addProperty(new FolderConfig("parent_docker", "https://parent.registry", grandParentCred.getId()));
+        Folder parent = grandParent.createProject(Folder.class, "testParent"); //Can be static since grandParent should be unique
+        getFolderStore(parent).addCredentials(Domain.global(), folderCred);
+        parent.addProperty(new FolderConfig("folder_docker", "https://folder.registry", folderCred.getId()));
+
+        expect("declarativeDockerConfig")
+                .inFolder(parent)
+                .runFromRepo(false)
+                .logContains("Docker Label is: folder_docker",
+                        "Registry URL is: https://folder.registry",
+                        "Registry Creds ID is: " + folderCred.getId())
+                .logNotContains("Docker Label is: parent_docker",
+                        "Registry URL is: https://parent.registry",
+                        "Registry Creds ID is: " + grandParentCred.getId()).go();
+    }
+
+    @Test
+    public void runsOnCorrectSlave() throws Exception {
+        assumeDocker();
+        Slave s = j.createOnlineSlave();
+        s.setLabelString("notthis");
+        env(s).put("DOCKER_INDICATOR", "WRONG").set();
+        s = j.createOnlineSlave();
+        s.setLabelString("thisone");
+        env(s).put("DOCKER_INDICATOR", "CORRECT").set();
+        GlobalConfig.get().setDockerLabel("thisone");
+        GlobalConfig.get().setRegistry(null);
+
+        expect("agent/agentDockerEnvTest").runFromRepo(false).logContains("Running on assumed Docker agent").go();
+
+    }
+
+    @Test
+    public void runsOnSpecifiedSlave() throws Exception {
+        assumeDocker();
+        Slave s = j.createOnlineSlave();
+        s.setLabelString("thisspec");
+        env(s).put("DOCKER_INDICATOR", "SPECIFIED").set();
+        s = j.createOnlineSlave();
+        s.setLabelString("thisone");
+        env(s).put("DOCKER_INDICATOR", "CORRECT").set();
+        GlobalConfig.get().setDockerLabel("thisone");
+        GlobalConfig.get().setRegistry(null);
+
+        expect("agent/agentDockerEnvSpecLabel").runFromRepo(false).logContains("Running on assumed Docker agent").go();
+
+    }
+
+    private CredentialsStore getFolderStore(Folder f) {
+        Iterable<CredentialsStore> stores = CredentialsProvider.lookupStores(f);
+        CredentialsStore folderStore = null;
+        for (CredentialsStore s : stores) {
+            if (s.getProvider() instanceof FolderCredentialsProvider && s.getContext() == f) {
+                folderStore = s;
+                break;
+            }
+        }
+        return folderStore;
+    }
+
+
+}

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerAgentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerAgentTest.java
@@ -1,0 +1,340 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.model.Result;
+import hudson.model.Slave;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.jenkinsci.plugins.docker.workflow.DockerTestUtil;
+import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import static org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest.j;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * Adapted from {@link org.jenkinsci.plugins.pipeline.modeldefinition.AgentTest}.
+ */
+public class DockerAgentTest extends AbstractModelDefTest {
+
+    private static Slave s;
+    private static Slave s2;
+
+    private static String password;
+    @BeforeClass
+    public static void setUpAgent() throws Exception {
+        s = j.createOnlineSlave();
+        s.setLabelString("some-label docker");
+        s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true"),
+                new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "first")));
+        s.setNumExecutors(2);
+
+        s2 = j.createOnlineSlave();
+        s2.setLabelString("other-docker");
+        s2.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true"),
+                new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "second")));
+        //setup credentials for docker registry
+        CredentialsStore store = CredentialsProvider.lookupStores(j.jenkins).iterator().next();
+
+        password = System.getProperty("docker.password");
+
+        if(password != null) {
+            UsernamePasswordCredentialsImpl globalCred =
+                    new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL,
+                            "dockerhub", "real", "jtaboada", password);
+
+            store.addCredentials(Domain.global(), globalCred);
+
+        }
+    }
+
+    @Test
+    public void agentDocker() throws Exception {
+        agentDocker("agent/agentDocker", "-v /tmp:/tmp");
+    }
+
+    @Test
+    public void agentDockerWithCreds() throws Exception {
+        //If there is no password, the test is ignored
+        if(password != null)
+            agentDocker("agent/agentDockerWithCreds", "-v /tmp:/tmp");
+    }
+
+    @Test
+    public void agentDockerWithRegistryNoCreds() throws Exception {
+        agentDocker("agent/agentDockerWithRegistryNoCreds",
+                "-v /tmp:/tmp",
+                "Registry is https://index.docker.io/v2/");
+    }
+
+    @Test
+    public void agentDockerReuseNode() throws Exception {
+        agentDocker("agent/agentDockerReuseNode");
+    }
+
+    @Issue("JENKINS-49558")
+    @Test
+    public void agentDockerContainerPerStage() throws Exception {
+        agentDocker("agent/agentDockerContainerPerStage");
+    }
+
+    @Issue("JENKINS-49558")
+    @Test
+    public void agentDockerWithoutContainerPerStage() throws Exception {
+        agentDocker("agent/agentDockerWithoutContainerPerStage");
+    }
+
+    @Test
+    public void agentDockerDontReuseNode() throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        expect(Result.FAILURE, "agent/agentDockerDontReuseNode")
+                .logContains("The answer is 42")
+                .go();
+
+    }
+
+    // Also covers agentAnyInStage, perStageConfigAgent
+    @Issue("JENKINS-41605")
+    @Test
+    public void agentInStageAutoCheckout() throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        expect("agent/agentInStageAutoCheckout")
+                .logContains("The answer is 42",
+                        "found tmp.txt in bar",
+                        "did not find tmp.txt in new docker node",
+                        "did not find tmp.txt in new label node")
+                .go();
+
+    }
+
+    @Test
+    public void agentDockerWithNullDockerArgs() throws Exception {
+        agentDocker("agent/agentDockerWithNullDockerArgs");
+    }
+
+    @Test
+    public void agentDockerWithEmptyDockerArgs() throws Exception {
+        agentDocker("agent/agentDockerWithEmptyDockerArgs");
+    }
+
+    @Issue("JENKINS-41950")
+    @Test
+    public void nonExistentDockerImage() throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        expect(Result.FAILURE, "agent/nonExistentDockerImage")
+                .logContains("ERROR: script returned exit code 1",
+                        "There is no image")
+                .go();
+    }
+
+
+    @Test
+    public void fromDockerfile() throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        sampleRepo.write("Dockerfile", "FROM ubuntu:14.04\n\nRUN echo 'HI THERE' > /hi-there\n\n");
+        sampleRepo.git("init");
+        sampleRepo.git("add", "Dockerfile");
+        sampleRepo.git("commit", "--message=Dockerfile");
+
+        expect("agent/fromDockerfile")
+                .logContains("[Pipeline] { (foo)",
+                        "The answer is 42",
+                        "-v /tmp:/tmp",
+                        "HI THERE")
+                .go();
+    }
+
+    @Test
+    public void additionalDockerBuildArgs() throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        sampleRepo.write("Dockerfile", "FROM ubuntu:14.04\n\nARG someArg=thisArgHere\n\nRUN echo \"hi there, $someArg\" > /hi-there\n\n");
+        sampleRepo.git("init");
+        sampleRepo.git("add", "Dockerfile");
+        sampleRepo.git("commit", "--message=Dockerfile");
+
+        expect("agent/additionalDockerBuildArgs")
+                .logContains("[Pipeline] { (foo)",
+                        "The answer is 42",
+                        "-v /tmp:/tmp",
+                        "hi there, thisOtherArg")
+                .logNotContains("hi there, thisArgHere")
+                .go();
+    }
+
+    @Issue("JENKINS-57162")
+    @Test
+    public void additionalDockerBuildArgsImageHash() throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        sampleRepo.write("Dockerfile",  "FROM ubuntu:14.04\n\nARG someArg=thisArgHere\n\nRUN echo \"hi there, $someArg\" > /hi-there\n\n");
+        sampleRepo.git("init");
+        sampleRepo.git("add", "Dockerfile");
+        sampleRepo.git("commit", "--message=Dockerfile");
+
+        Folder folder = j.jenkins.createProject(Folder.class, "testFolder");
+        expect("agent/additionalDockerBuildArgsParallel")
+                .inFolder(folder)
+                .withProjectName("parallelImageHashTest")
+                .logContains("[Pipeline] { (foo)",
+                        "-v /tmp:/tmp",
+                        "docker build -t 8343c0815beb7a50c3676f09d7175d903a57f11b --build-arg someArg=thisOtherArg",
+                        "The answer is 42",
+                        "hi there, thisOtherArg",
+                        "[Pipeline] { (bar)",
+                        "docker build -t 4f8d74de557925eb9aacdfdf671b5e9de11b6086 --build-arg someArg=thisDifferentArg",
+                        "The answer is 43",
+                        "hi there, thisDifferentArg")
+                .logNotContains("hi there, thisArgHere")
+                .go();
+    }
+
+    @Issue("JENKINS-41668")
+    @Test
+    public void fromDockerfileInOtherDir() throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        sampleRepo.write("subdir/Dockerfile", "FROM ubuntu:14.04\n\nRUN echo 'HI THERE' > /hi-there\n\n");
+        sampleRepo.git("init");
+        sampleRepo.git("add", "subdir/Dockerfile");
+        sampleRepo.git("commit", "--message=Dockerfile");
+
+        expect("agent/fromDockerfileInOtherDir")
+                .logContains("[Pipeline] { (foo)",
+                        "The answer is 42",
+                        "-v /tmp:/tmp",
+                        "HI THERE")
+                .go();
+    }
+
+    @Issue("JENKINS-42286")
+    @Test
+    public void dirSepInDockerfileName() throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        sampleRepo.write("subdir/Dockerfile", "FROM ubuntu:14.04\n\nRUN echo 'HI THERE' > /hi-there\n\n");
+        sampleRepo.git("init");
+        sampleRepo.git("add", "subdir/Dockerfile");
+        sampleRepo.git("commit", "--message=Dockerfile");
+
+        expect("agent/fromDockerfileInOtherDir")
+                .logContains("[Pipeline] { (foo)",
+                        "The answer is 42",
+                        "-v /tmp:/tmp",
+                        "HI THERE")
+                .go();
+    }
+
+    @Test
+    public void fromDockerfileNoArgs() throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        sampleRepo.write("Dockerfile", "FROM ubuntu:14.04\n\nRUN echo 'HI THERE' > /hi-there\n\n");
+        sampleRepo.git("init");
+        sampleRepo.git("add", "Dockerfile");
+        sampleRepo.git("commit", "--message=Dockerfile");
+
+        expect("agent/fromDockerfileNoArgs")
+                .logContains("[Pipeline] { (foo)",
+                        "The answer is 42",
+                        "HI THERE")
+                .go();
+    }
+
+    @Test
+    public void fromAlternateDockerfile() throws Exception {
+        DockerTestUtil.assumeDocker();
+        sampleRepo.write("Dockerfile.alternate", "FROM ubuntu:14.04\n\nRUN echo 'HI THERE' > /hi-there\n\n");
+        sampleRepo.git("init");
+        sampleRepo.git("add", "Dockerfile.alternate");
+        sampleRepo.git("commit", "--message=Dockerfile");
+
+        expect("agent/fromAlternateDockerfile")
+                .logContains("[Pipeline] { (foo)",
+                        "The answer is 42",
+                        "-v /tmp:/tmp",
+                        "HI THERE")
+                .go();
+    }
+
+    @Ignore("Until JENKINS-46831 is addressed")
+    @Issue("JENKINS-46831")
+    @Test
+    public void agentDockerGlobalThenLabel() throws Exception {
+        expect("agent/agentDockerGlobalThenLabel")
+            .logContains(
+                "first agent = first",
+                "second agent = second"
+            )
+            .go();
+    }
+
+    @Issue("JENKINS-47106")
+    @Test
+    public void dockerPullLocalImage() throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        sampleRepo.write("Dockerfile", "FROM ubuntu:14.04\n\nRUN echo 'HI THERE' > /hi-there\n\n");
+        sampleRepo.git("init");
+        sampleRepo.git("add", "Dockerfile");
+        sampleRepo.git("commit", "--message=Dockerfile");
+
+        expect("dockerPullLocalImage")
+                .logContains("[Pipeline] { (in built image)",
+                        "The answer is 42",
+                        "-v /tmp:/tmp",
+                        "HI THERE",
+                        "Maven home: /usr/share/maven")
+                .go();
+    }
+
+    private void agentDocker(final String jenkinsfile, String... additionalLogContains) throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        List<String> logContains = new ArrayList<>();
+        logContains.add("[Pipeline] { (foo)");
+        logContains.add("The answer is 42");
+        logContains.addAll(Arrays.asList(additionalLogContains));
+
+        expect(jenkinsfile)
+                .logContains(logContains.toArray(new String[logContains.size()]))
+                .go();
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerBasicModelDefTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerBasicModelDefTest.java
@@ -24,12 +24,14 @@
 
 package org.jenkinsci.plugins.docker.workflow.declarative;
 
+import hudson.model.Result;
 import hudson.model.Slave;
 import org.jenkinsci.plugins.docker.workflow.DockerTestUtil;
 import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
 import static org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest.j;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 /**
  * Adapted from {@link org.jenkinsci.plugins.pipeline.modeldefinition.BasicModelDefTest}.
@@ -51,6 +53,16 @@ public class DockerBasicModelDefTest extends AbstractModelDefTest {
 
         expect("dockerGlobalVariable")
                 .logContains("[Pipeline] { (foo)", "image: ubuntu")
+                .go();
+    }
+
+    @Issue("JENKINS-40226")
+    @Test
+    public void failureBeforeStages() throws Exception {
+        // This should fail whether we've got Docker available or not. Hopefully.
+        expect(Result.FAILURE, "failureBeforeStages")
+                .logContains("Dockerfile failed")
+                .logNotContains("This should never happen")
                 .go();
     }
 

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerBasicModelDefTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerBasicModelDefTest.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import hudson.model.Slave;
+import org.jenkinsci.plugins.docker.workflow.DockerTestUtil;
+import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import static org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest.j;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Adapted from {@link org.jenkinsci.plugins.pipeline.modeldefinition.BasicModelDefTest}.
+ */
+public class DockerBasicModelDefTest extends AbstractModelDefTest {
+
+    private static Slave s;
+
+    @BeforeClass
+    public static void setUpAgent() throws Exception {
+        s = j.createOnlineSlave();
+        s.setNumExecutors(10);
+        s.setLabelString("some-label docker");
+    }
+
+    @Test
+    public void dockerGlobalVariable() throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        expect("dockerGlobalVariable")
+                .logContains("[Pipeline] { (foo)", "image: ubuntu")
+                .go();
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerDirectiveGeneratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerDirectiveGeneratorTest.java
@@ -1,0 +1,208 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.WebResponse;
+import com.gargoylesoftware.htmlunit.util.NameValuePair;
+import hudson.model.Describable;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import jenkins.model.OptionalJobProperty;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.pipeline.modeldefinition.generator.AbstractDirective;
+import org.jenkinsci.plugins.pipeline.modeldefinition.generator.AgentDirective;
+import org.jenkinsci.plugins.pipeline.modeldefinition.generator.DirectiveGenerator;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.jenkinsci.plugins.structs.describable.DescribableParameter;
+import static org.junit.Assert.assertEquals;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.ToolInstallations;
+
+/**
+ * Adapted from {@code org.jenkinsci.plugins.pipeline.modeldefinition.generator.DirectiveGeneratorTest}.
+ */
+public class DockerDirectiveGeneratorTest {
+
+    @ClassRule
+    public static JenkinsRule r = new JenkinsRule();
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ToolInstallations.configureMaven3();
+    }
+
+    @Test
+    public void simpleAgentDocker() throws Exception {
+        AgentDirective agent = new AgentDirective(new DockerPipeline("some-image"));
+        assertGenerateDirective(agent, "agent {\n" +
+                "  docker 'some-image'\n" +
+                "}");
+    }
+
+    @Test
+    public void fullAgentDocker() throws Exception {
+        DockerPipeline dockerPipeline = new DockerPipeline("some-image");
+        dockerPipeline.setAlwaysPull(true);
+        dockerPipeline.setArgs("--some-arg");
+        dockerPipeline.setCustomWorkspace("some/path");
+        dockerPipeline.setLabel("some-label");
+        dockerPipeline.setRegistryCredentialsId("some-cred-id");
+        dockerPipeline.setReuseNode(true);
+        dockerPipeline.setRegistryUrl("http://some.where");
+        AgentDirective agent = new AgentDirective(dockerPipeline);
+
+        assertGenerateDirective(agent, "agent {\n" +
+                "  docker {\n" +
+                "    alwaysPull true\n" +
+                "    args '--some-arg'\n" +
+                "    customWorkspace 'some/path'\n" +
+                "    image 'some-image'\n" +
+                "    label 'some-label'\n" +
+                "    registryCredentialsId 'some-cred-id'\n" +
+                "    registryUrl 'http://some.where'\n" +
+                "    reuseNode true\n" +
+                "  }\n" +
+                "}");
+    }
+
+    @Test
+    public void simpleAgentDockerfile() throws Exception {
+        AgentDirective agent = new AgentDirective(new DockerPipelineFromDockerfile());
+
+        assertGenerateDirective(agent, "agent {\n" +
+                "  dockerfile true\n" +
+                "}");
+    }
+
+    @Test
+    public void fullAgentDockerfile() throws Exception {
+        DockerPipelineFromDockerfile dp = new DockerPipelineFromDockerfile();
+        dp.setAdditionalBuildArgs("--additional-arg");
+        dp.setDir("some-sub/dir");
+        dp.setFilename("NotDockerfile");
+        dp.setArgs("--some-arg");
+        dp.setCustomWorkspace("/custom/workspace");
+        dp.setLabel("some-label");
+        AgentDirective agent = new AgentDirective(dp);
+
+        assertGenerateDirective(agent, "agent {\n" +
+                "  dockerfile {\n" +
+                "    additionalBuildArgs '--additional-arg'\n" +
+                "    args '--some-arg'\n" +
+                "    customWorkspace '/custom/workspace'\n" +
+                "    dir 'some-sub/dir'\n" +
+                "    filename 'NotDockerfile'\n" +
+                "    label 'some-label'\n" +
+                "  }\n" +
+                "}");
+    }
+
+    private void assertGenerateDirective(@Nonnull AbstractDirective desc, @Nonnull String responseText) throws Exception {
+        // First, make sure the expected response text actually matches the toGroovy for the directive.
+        assertEquals(desc.toGroovy(true), responseText);
+
+        // Then submit the form with the appropriate JSON (we generate it from the directive, but it matches the form JSON exactly)
+        JenkinsRule.WebClient wc = r.createWebClient();
+        WebRequest wrs = new WebRequest(new URL(r.getURL(), DirectiveGenerator.GENERATE_URL), HttpMethod.POST);
+        List<NameValuePair> params = new ArrayList<NameValuePair>();
+        params.add(new NameValuePair("json", staplerJsonForDescr(desc).toString()));
+        // WebClient.addCrumb *replaces* rather than *adds*:
+        params.add(new NameValuePair(r.jenkins.getCrumbIssuer().getDescriptor().getCrumbRequestField(), r.jenkins.getCrumbIssuer().getCrumb(null)));
+        wrs.setRequestParameters(params);
+        WebResponse response = wc.getPage(wrs).getWebResponse();
+        assertEquals("text/plain", response.getContentType());
+        assertEquals(responseText, response.getContentAsString().trim());
+    }
+
+    private Object getValue(DescribableParameter p, Object o) {
+        Class<?> ownerClass = o.getClass();
+        try {
+            try {
+                return ownerClass.getField(p.getName()).get(o);
+            } catch (NoSuchFieldException x) {
+                // OK, check for getter instead
+            }
+            try {
+                return ownerClass.getMethod("get" + p.getCapitalizedName()).invoke(o);
+            } catch (NoSuchMethodException x) {
+                // one more check
+            }
+            try {
+                return ownerClass.getMethod("is" + p.getCapitalizedName()).invoke(o);
+            } catch (NoSuchMethodException x) {
+                throw new UnsupportedOperationException("no public field ‘" + p.getName() + "’ (or getter method) found in " + ownerClass);
+            }
+        } catch (UnsupportedOperationException x) {
+            throw x;
+        } catch (Exception x) {
+            throw new UnsupportedOperationException(x);
+        }
+    }
+
+    private JSONObject staplerJsonForDescr(Describable d) {
+        DescribableModel<?> m = DescribableModel.of(d.getClass());
+
+        JSONObject o = new JSONObject();
+        o.accumulate("stapler-class", d.getClass().getName());
+        o.accumulate("$class", d.getClass().getName());
+        if (d instanceof OptionalJobProperty) {
+            o.accumulate("specified", true);
+        }
+        for (DescribableParameter param : m.getParameters()) {
+            Object v = getValue(param, d);
+            if (v != null) {
+                if (v instanceof Describable) {
+                    o.accumulate(param.getName(), staplerJsonForDescr((Describable)v));
+                } else if (v instanceof List && !((List) v).isEmpty()) {
+                    JSONArray a = new JSONArray();
+                    for (Object obj : (List) v) {
+                        if (obj instanceof Describable) {
+                            a.add(staplerJsonForDescr((Describable) obj));
+                        } else if (obj instanceof Number) {
+                            a.add(obj.toString());
+                        } else {
+                            a.add(obj);
+                        }
+                    }
+                    o.accumulate(param.getName(), a);
+                } else if (v instanceof Number) {
+                    o.accumulate(param.getName(), v.toString());
+                } else {
+                    o.accumulate(param.getName(), v);
+                }
+            }
+        }
+        return o;
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerDirectiveGeneratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerDirectiveGeneratorTest.java
@@ -49,7 +49,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.ToolInstallations;
 
 /**
- * Adapted from {@code org.jenkinsci.plugins.pipeline.modeldefinition.generator.DirectiveGeneratorTest}.
+ * Adapted from {@link org.jenkinsci.plugins.pipeline.modeldefinition.generator.DirectiveGeneratorTest}.
  */
 public class DockerDirectiveGeneratorTest {
 

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerPostStageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerPostStageTest.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import org.jenkinsci.plugins.docker.workflow.DockerTestUtil;
+import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * Adapted from {@link org.jenkinsci.plugins.pipeline.modeldefinition.PostStageTest}.
+ */
+public class DockerPostStageTest extends AbstractModelDefTest {
+
+    @Issue("JENKINS-46276")
+    @Test
+    public void withAgentNoneAndAgentDocker() throws Exception {
+        DockerTestUtil.assumeDocker();
+        expect("org/jenkinsci/plugins/docker/workflow/declarative/withAgentNoneAndAgentDocker")
+                .logNotContains("Required context class hudson.FilePath is missing").go();
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerScriptStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerScriptStepTest.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import hudson.model.Slave;
+import org.jenkinsci.plugins.docker.workflow.DockerTestUtil;
+import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import static org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest.j;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Adapted from {@link org.jenkinsci.plugins.pipeline.modeldefinition.ScriptStepTest}.
+ */
+public class DockerScriptStepTest extends AbstractModelDefTest {
+
+    private static Slave s;
+
+    @BeforeClass
+    public static void setUpAgent() throws Exception {
+        s = j.createOnlineSlave();
+        s.setLabelString("some-label docker");
+    }
+
+    @Test
+    public void dockerGlobalVariableInScript() throws Exception {
+        DockerTestUtil.assumeDocker();
+
+        expect("dockerGlobalVariableInScript")
+                .logContains("[Pipeline] { (foo)", "image: ubuntu")
+                .go();
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/ExtensionFilterImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/ExtensionFilterImplTest.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+@Issue("JENKINS-58732")
+public class ExtensionFilterImplTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void noOverlap() throws Exception {
+        Map<String, DeclarativeAgentDescriptor> dads = new HashMap<>();
+        for (DeclarativeAgentDescriptor dad : DeclarativeAgentDescriptor.all()) {
+            DeclarativeAgentDescriptor dad2 = dads.put(dad.getName(), dad);
+            assertNull("clash between " + dad2 + " and " + dad, dad2);
+        }
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfigTest.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.docker.workflow.declarative;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class GlobalConfigTest {
+
+    @Rule
+    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    @Issue("JENKINS-42027")
+    @Test
+    public void globalConfigPersists() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                GlobalConfig.get().setDockerLabel("config_docker");
+                GlobalConfig.get().save();
+            }
+        });
+
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                assertEquals("config_docker", GlobalConfig.get().getDockerLabel());
+            }
+        });
+    }
+
+}

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/additionalDockerBuildArgs.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/additionalDockerBuildArgs.groovy
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        dockerfile {
+            args "-v /tmp:/tmp"
+            additionalBuildArgs "--build-arg someArg=thisOtherArg"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /hi-there'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/additionalDockerBuildArgsParallel.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/additionalDockerBuildArgsParallel.groovy
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+
+    stages {
+        stage("test") {
+            parallel {
+                stage("foo") {
+                    agent {
+                        dockerfile {
+                            args "-v /tmp:/tmp"
+                            additionalBuildArgs "--build-arg someArg=thisOtherArg"
+                        }
+                    }
+                    steps {
+                        sh 'cat /hi-there'
+                        sh 'echo "The answer is 42"'
+                    }
+                }
+                stage("bar") {
+                    agent {
+                        dockerfile {
+                            args "-v /tmp:/tmp"
+                            additionalBuildArgs "--build-arg someArg=thisDifferentArg"
+                        }
+                    }
+                    steps {
+                        sh 'cat /hi-there'
+                        sh 'echo "The answer is 43"'
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDocker.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDocker.groovy
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        docker {
+            image "httpd:2.4.12"
+            args "-v /tmp:/tmp"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /usr/local/apache2/conf/extra/httpd-userdir.conf'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDocker.json
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDocker.json
@@ -1,0 +1,49 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps":       [
+                {
+          "name": "sh",
+          "arguments": [          {
+            "key": "script",
+            "value":             {
+              "isLiteral": true,
+              "value": "cat /usr/local/apache2/conf/extra/httpd-userdir.conf"
+            }
+          }]
+        },
+                {
+          "name": "sh",
+          "arguments": [          {
+            "key": "script",
+            "value":             {
+              "isLiteral": true,
+              "value": "echo \"The answer is 42\""
+            }
+          }]
+        }
+      ]
+    }]
+  }],
+  "agent":   {
+    "type": "docker",
+    "arguments":     [
+            {
+        "key": "image",
+        "value":         {
+          "isLiteral": true,
+          "value": "httpd:2.4.12"
+        }
+      },
+            {
+        "key": "args",
+        "value":         {
+          "isLiteral": true,
+          "value": "-v /tmp:/tmp"
+        }
+      }
+    ]
+  }
+}}

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerContainerPerStage.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerContainerPerStage.groovy
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        docker {
+            image "httpd:2.4.12"
+            label "docker"
+        }
+    }
+    options {
+        newContainerPerStage()
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'ls -la'
+                sh 'echo "The answer is 42"'
+                sh 'echo "${NODE_NAME}" > tmp.txt'
+                sh 'echo $HOSTNAME > host.txt'
+            }
+        }
+        stage("bar") {
+            steps {
+                sh 'test -f Jenkinsfile'
+                sh 'test -f tmp.txt'
+                script {
+                    def oldHn = readFile('host.txt')
+                    def newHn = sh(script:'echo $HOSTNAME', returnStdout:true)
+                    if (oldHn == newHn) {
+                        error("HOSTNAMES SHOULD NOT MATCH")
+                    }
+                }
+            }
+
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerDontReuseNode.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerDontReuseNode.groovy
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+
+    stages {
+        stage("foo") {
+            agent {
+                label "docker"
+            }
+            steps {
+                sh 'ls -la'
+                sh 'echo "The answer is 42"'
+                sh 'echo "${NODE_NAME}" > tmp.txt'
+            }
+        }
+        stage("bar") {
+            agent {
+                docker {
+                    label "other-docker"
+                    image "httpd:2.4.12"
+                    reuseNode true
+                }
+            }
+            steps {
+                sh 'test -f tmp.txt'
+            }
+
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerEnvSpecLabel.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerEnvSpecLabel.groovy
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+
+
+
+pipeline {
+    agent {
+        docker {
+            label "thisspec"
+            image "httpd:2.4.12"
+            args "-v /tmp:/tmp"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                script {
+                    if (env.DOCKER_INDICATOR != "SPECIFIED") {
+                        error "Not the assumed Docker agent"
+                    } else {
+                        echo "Running on assumed Docker agent"
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerEnvTest.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerEnvTest.groovy
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+
+
+
+pipeline {
+    agent {
+        docker {
+            image "httpd:2.4.12"
+            args "-v /tmp:/tmp"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                script {
+                    if (env.DOCKER_INDICATOR != "CORRECT") {
+                        error "Not the assumed Docker agent"
+                    } else {
+                        echo "Running on assumed Docker agent"
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerGlobalThenLabel.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerGlobalThenLabel.groovy
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+
+
+
+pipeline {
+    agent {
+        docker {
+            image 'maven:3.5.0-jdk-8-alpine'
+            label 'docker'
+        }
+    }
+    stages {
+        stage("Maven") {
+            steps { sh 'echo "first agent = $WHICH_AGENT"' }
+        }
+        stage("Agent") {
+            agent { label 'other-docker' }
+            steps { sh 'echo "second agent = $WHICH_AGENT"' }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerReuseNode.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerReuseNode.groovy
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        label "docker"
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'ls -la'
+                sh 'echo "The answer is 42"'
+                sh 'echo "${NODE_NAME}" > tmp.txt'
+            }
+        }
+        stage("bar") {
+            agent {
+                docker {
+                    image "httpd:2.4.12"
+                    reuseNode true
+                }
+            }
+            steps {
+                sh 'test -f Jenkinsfile'
+                sh 'test -f tmp.txt'
+            }
+
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithCreds.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithCreds.groovy
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        docker {
+            alwaysPull true
+            registryCredentialsId "dockerhub"
+            image "jtaboada/httpd:2.4.12"
+            args "-v /tmp:/tmp"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /usr/local/apache2/conf/extra/httpd-userdir.conf'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithEmptyDockerArgs.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithEmptyDockerArgs.groovy
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        docker {
+            image "httpd:2.4.12"
+            args ""
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /usr/local/apache2/conf/extra/httpd-userdir.conf'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithNullDockerArgs.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithNullDockerArgs.groovy
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        docker {
+            image "httpd:2.4.12"
+            args null
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /usr/local/apache2/conf/extra/httpd-userdir.conf'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithRegistryNoCreds.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithRegistryNoCreds.groovy
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        docker {
+            alwaysPull true
+            image "httpd:2.4.12"
+            registryUrl "https://index.docker.io/v2/"
+            args "-v /tmp:/tmp"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /usr/local/apache2/conf/extra/httpd-userdir.conf'
+                sh 'echo "The answer is 42"'
+                echo "Registry is ${env.DOCKER_REGISTRY_URL}"
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithoutContainerPerStage.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithoutContainerPerStage.groovy
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        docker {
+            image "httpd:2.4.12"
+            label "docker"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'ls -la'
+                sh 'echo "The answer is 42"'
+                sh 'echo "${NODE_NAME}" > tmp.txt'
+                sh 'echo $HOSTNAME > host.txt'
+            }
+        }
+        stage("bar") {
+            steps {
+                sh 'test -f Jenkinsfile'
+                sh 'test -f tmp.txt'
+                script {
+                    def oldHn = readFile('host.txt')
+                    def newHn = sh(script:'echo $HOSTNAME', returnStdout:true)
+                    if (oldHn != newHn) {
+                        error("HOSTNAMES SHOULD MATCH")
+                    }
+                }
+            }
+
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentInStageAutoCheckout.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentInStageAutoCheckout.groovy
@@ -1,0 +1,75 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        label "docker"
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'ls -la'
+                sh 'echo "The answer is 42"'
+                sh 'echo "${NODE_NAME}" > tmp.txt'
+            }
+        }
+        stage("bar") {
+            agent {
+                docker {
+                    image "httpd:2.4.12"
+                    reuseNode true
+                }
+            }
+            steps {
+                sh 'test -f Jenkinsfile'
+                sh 'test -f tmp.txt'
+                echo "found tmp.txt in bar"
+            }
+        }
+        stage("new node - docker") {
+            agent {
+                docker {
+                    image "httpd:2.4.12"
+                }
+            }
+            steps {
+                sh 'test -f Jenkinsfile'
+                sh 'test ! -f tmp.txt'
+                echo "did not find tmp.txt in new docker node"
+            }
+        }
+        stage("new node - label") {
+            agent any
+
+            steps {
+                sh 'test -f Jenkinsfile'
+                sh 'test ! -f tmp.txt'
+                echo "did not find tmp.txt in new label node"
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig.groovy
@@ -1,0 +1,30 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeDockerUtils
+
+
+echo "Docker Label is: ${DeclarativeDockerUtils.getLabel()}"
+echo "Registry URL is: ${DeclarativeDockerUtils.getRegistryUrl()}"
+echo "Registry Creds ID is: ${DeclarativeDockerUtils.getRegistryCredentialsId()}"

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig.groovy
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  *
  */
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeDockerUtils
+import org.jenkinsci.plugins.docker.workflow.declarative.DeclarativeDockerUtils
 
 
 echo "Docker Label is: ${DeclarativeDockerUtils.getLabel()}"

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfigWithOverride.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfigWithOverride.groovy
@@ -1,0 +1,29 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeDockerUtils
+
+echo "Docker Label is: ${DeclarativeDockerUtils.getLabel('other-label')}"
+echo "Registry URL is: ${DeclarativeDockerUtils.getRegistryUrl('https://other.registry')}"
+echo "Registry Creds ID is: ${DeclarativeDockerUtils.getRegistryCredentialsId('grandParentCreds')}"

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfigWithOverride.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfigWithOverride.groovy
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeDockerUtils
+import org.jenkinsci.plugins.docker.workflow.declarative.DeclarativeDockerUtils
 
 echo "Docker Label is: ${DeclarativeDockerUtils.getLabel('other-label')}"
 echo "Registry URL is: ${DeclarativeDockerUtils.getRegistryUrl('https://other.registry')}"

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/dirSepInDockerfileName.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/dirSepInDockerfileName.groovy
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        dockerfile {
+            filename "subdir/Dockerfile"
+            args "-v /tmp:/tmp"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /hi-there'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/dockerGlobalVariable.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/dockerGlobalVariable.groovy
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+pipeline {
+    agent {
+        label "some-label"
+    }
+    stages {
+        stage("foo") {
+            steps {
+                // This only works because it's an argument, not the step.
+                echo "image: ${docker.image('ubuntu').imageName()}"
+            }
+        }
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/dockerGlobalVariableInScript.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/dockerGlobalVariableInScript.groovy
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+pipeline {
+    agent {
+        label "some-label"
+    }
+    stages {
+        stage("foo") {
+            steps {
+                script {
+                    foo = docker.image('ubuntu')
+                    echo "image: ${foo.imageName()}"
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/dockerPullLocalImage.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/dockerPullLocalImage.groovy
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    stages {
+        stage("build image") {
+            steps {
+                sh 'docker build -t maven:3-alpine .'
+            }
+        }
+        stage("in built image") {
+            agent {
+                docker {
+                    image "maven:3-alpine"
+                    args "-v /tmp:/tmp"
+                    reuseNode true
+                }
+            }
+            steps {
+                sh 'cat /hi-there'
+                sh 'echo "The answer is 42"'
+            }
+        }
+        stage("in pulled image") {
+            agent {
+                docker {
+                    image "maven:3-alpine"
+                    alwaysPull true
+                }
+            }
+            steps {
+                sh 'mvn --version'
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/failureBeforeStages.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/failureBeforeStages.groovy
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        dockerfile {
+            args "-v /tmp:/tmp"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /hi-there'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+    post {
+        failure {
+            echo "Dockerfile failed"
+        }
+        success {
+            echo "This should never happen"
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/fromAlternateDockerfile.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/fromAlternateDockerfile.groovy
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        dockerfile {
+            filename "Dockerfile.alternate"
+            args "-v /tmp:/tmp"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /hi-there'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/fromDockerfile.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/fromDockerfile.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        dockerfile {
+            args "-v /tmp:/tmp"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /hi-there'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/fromDockerfileInOtherDir.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/fromDockerfileInOtherDir.groovy
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        dockerfile {
+            args "-v /tmp:/tmp"
+            dir "subdir"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /hi-there'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/fromDockerfileNoArgs.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/fromDockerfileNoArgs.groovy
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        dockerfile true
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /hi-there'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/nonExistentDockerImage.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/nonExistentDockerImage.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        docker {
+            image "httpdIDontExist:2.4.12"
+            args "-v /tmp:/tmp"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /usr/local/apache2/conf/extra/httpd-userdir.conf'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+    post {
+        always {
+            echo "There is no image"
+            deleteDir()
+        }
+    }
+}
+
+
+

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/withAgentNoneAndAgentDocker.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/withAgentNoneAndAgentDocker.groovy
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+pipeline {
+    agent none
+    options {
+        skipDefaultCheckout()
+    }
+    stages {
+        stage("Do It") {
+            agent {
+                docker {
+                    image 'maven:3-alpine'
+                    args '-v $HOME/.m2:/root/.m2'
+                }
+            }
+            steps {
+                writeFile file: "hello.txt", text: "Hello World"
+            }
+            post {
+                success {
+                    archive '*.txt'
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
[JENKINS-58732](https://issues.jenkins-ci.org/browse/JENKINS-58732)

- [X] main code moved
- [x] tests moved
- [x] original extensions suppressed
- [X] interactively test upgrade scenarios in a realistic class loading environment

Reviewers’ guide to the big diff:

* Most changes are simply files moved verbatim from https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/373.
  * `package` and `import` statements were fixed up where necessary.
* Most new test classes consist of methods moved verbatim from original classes which also held non-Docker-specific tests.
  * Plus copies of `@Before` methods and the like as needed.
  * `DockerTestUtils` used for `assertDocker` (the version in `pipeline-model-definition-plugin` was evidently a clone of this).
* `Jenkinsfile` change is probably unrelated (CI environmental problems).
* `pom.xml` change mostly reflects the change of dependencies, plus upper bounds.
* `Messages.properties` extracts keys used only in extracted classes.
* `ExtensionFilterImpl` is novel.
* https://github.com/jenkinsci/docker-workflow-plugin/pull/202/commits/daad17b90ed0e8ae40ae488bcb2b6c74dbba7205 (a bit of reflection from Groovy) is novel.

Rollout plan (this is where [JENKINS-49651](https://issues.jenkins-ci.org/browse/JENKINS-49651) would be really nice):

* Release this PR first. It is safe to run just this update: you will have two copies of the Docker agent functionality but only the one from this plugin will be active. _(tested with snapshots)_
* Bump the dependency in https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/373 to the release version here, and release that PR too. It is safe to run both updates; the dependency in that PR is unused and merely guides users to get this update. Otherwise they might update only `pipeline-model-definition` and lose Docker agent functionality. _(tested with snapshots)_
* After some time has passed (weeks?), drop the unused dependency in `pipeline-model-definition` so it can be used independently. Mark with `compatibleSince` as a warning to users doing infrequent upgrades that they will need to have updated `docker-workflow` if they use this functionality.
* After some more time has passed, update the `pipeline-model-definition-plugin.version` here to the version that has no dependency on `docker-workflow`, add a dependency on `pipeline-model-definition` rather than just `pipeline-model-extensions` (which would then not trigger a plugin dependency cycle), and replace the uses of reflection with a direct call. (Or with a supported API in `pipeline-model-api` or `pipeline-model-extensions`; it seems yucky that it is using these supposedly implementation classes.)