### PR TITLE
JENKINS-57129 Bugfix for : Unexpected cgroup syntax

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
@@ -62,21 +62,23 @@ public class ControlGroup {
         // 7:cpu:/ecs/0410eff2-7e59-4111-823e-1e0d98ef7f30/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
         // 8:cpuset:/kubepods.slice/kubepods-pod9c26dfb6_b9c9_11e7_bfb9_02c6c1fc4861.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope
         // 12:freezer:/actions_job/ddecc467e1fb3295425e663efb6531282c1c936f25a3eeb7bb64e7b0fc61a216
+        // /kubepods/burstable/pod1fe52ba4-5709-11ea-9ee3-00505682780f/d65c8853fa45d139ce95d5c2b68a6e4aa8da83894d8eb0396cd6edd1c134c97c/user.slice
 
-        Pattern regex = Pattern.compile("([a-z0-9]{64})");
-        Matcher matcher = regex.matcher(group);
+        Matcher matcher = Pattern.compile("([a-z0-9]{64})").matcher(group);
 
         String containerId = null; 
         
-        while (matcher.find()) {
+        while ( matcher.find() ) {
           containerId = matcher.group();
         }
 
-        if (containerId != null) {
-          return containerId;
-        } else {
-          throw new IOException("Unexpected cgroup syntax "+group);
+        if ( null == containerId && 
+            Pattern.compile("^(\\/docker\\/|\\/ecs\\/|\\/docker-|\\/kubepods\\/|\\/actions_job\\/).*").matcher(group).matches() ) 
+        {
+          throw new IOException( "Unexpected cgroup syntax " + group );
         }
+
+        return containerId;
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
@@ -30,9 +30,15 @@ public class ControlGroup {
 
     private ControlGroup(String line) throws NumberFormatException, IndexOutOfBoundsException {
         String[] fields = line.split(":");
-        id = Integer.parseInt(fields[0]);
-        subsystems = fields[1];
-        group = fields[2];
+        if (fields.length > 1) {
+            id = Integer.parseInt(fields[0]);
+            subsystems = fields[1];
+            group = fields[2];
+        } else {
+            id = -1;
+            subsystems = "None";
+            group = fields[0];
+        }
     }
 
 

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
@@ -62,7 +62,7 @@ public class ControlGroup {
         // 7:cpu:/ecs/0410eff2-7e59-4111-823e-1e0d98ef7f30/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b
         // 8:cpuset:/kubepods.slice/kubepods-pod9c26dfb6_b9c9_11e7_bfb9_02c6c1fc4861.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope
         // 12:freezer:/actions_job/ddecc467e1fb3295425e663efb6531282c1c936f25a3eeb7bb64e7b0fc61a216
-        // /kubepods/burstable/pod1fe52ba4-5709-11ea-9ee3-00505682780f/d65c8853fa45d139ce95d5c2b68a6e4aa8da83894d8eb0396cd6edd1c134c97c/user.slice
+        // 11:pids:/kubepods/burstable/pod1fe52ba4-5709-11ea-9ee3-00505682780f/d65c8853fa45d139ce95d5c2b68a6e4aa8da83894d8eb0396cd6edd1c134c97c/user.slice
 
         Matcher matcher = Pattern.compile("([a-z0-9]{64})").matcher(group);
 

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
@@ -30,15 +30,9 @@ public class ControlGroup {
 
     private ControlGroup(String line) throws NumberFormatException, IndexOutOfBoundsException {
         String[] fields = line.split(":");
-        if (fields.length > 1) {
-            id = Integer.parseInt(fields[0]);
-            subsystems = fields[1];
-            group = fields[2];
-        } else {
-            id = -1;
-            subsystems = "None";
-            group = fields[0];
-        }
+        id = Integer.parseInt(fields[0]);
+        subsystems = fields[1];
+        group = fields[2];
     }
 
 

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroupTest.java
@@ -24,6 +24,7 @@ public class ControlGroupTest {
             "8:cpuset:/kubepods/besteffort/pod60070ae4-c63a-11e7-92b3-0adc1ac11520/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
             "7:cpu:/ecs/0410eff2-7e59-4111-823e-1e0d98ef7f30/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
             "2:cpu:/docker-ce/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
+            "2:cpu:/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b/user/jenkins/0",
             "/kubepods/burstable/pod1fe52ba4-5709-11ea-9ee3-00505682780f/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b/user.slice"
         };
 

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroupTest.java
@@ -24,7 +24,7 @@ public class ControlGroupTest {
             "8:cpuset:/kubepods/besteffort/pod60070ae4-c63a-11e7-92b3-0adc1ac11520/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
             "7:cpu:/ecs/0410eff2-7e59-4111-823e-1e0d98ef7f30/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
             "2:cpu:/docker-ce/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
-            "/kubepods/burstable/pod1fe52ba4-5709-11ea-9ee3-00505682780f/d65c8853fa45d139ce95d5c2b68a6e4aa8da83894d8eb0396cd6edd1c134c97c/us    er.slice"
+            "/kubepods/burstable/pod1fe52ba4-5709-11ea-9ee3-00505682780f/d65c8853fa45d139ce95d5c2b68a6e4aa8da83894d8eb0396cd6edd1c134c97c/user.slice"
         };
 
         for (final String possibleCgroupString : possibleCgroupStrings) {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroupTest.java
@@ -24,7 +24,7 @@ public class ControlGroupTest {
             "8:cpuset:/kubepods/besteffort/pod60070ae4-c63a-11e7-92b3-0adc1ac11520/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
             "7:cpu:/ecs/0410eff2-7e59-4111-823e-1e0d98ef7f30/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
             "2:cpu:/docker-ce/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
-            "/kubepods/burstable/pod1fe52ba4-5709-11ea-9ee3-00505682780f/d65c8853fa45d139ce95d5c2b68a6e4aa8da83894d8eb0396cd6edd1c134c97c/user.slice"
+            "/kubepods/burstable/pod1fe52ba4-5709-11ea-9ee3-00505682780f/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b/user.slice"
         };
 
         for (final String possibleCgroupString : possibleCgroupStrings) {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroupTest.java
@@ -25,7 +25,7 @@ public class ControlGroupTest {
             "7:cpu:/ecs/0410eff2-7e59-4111-823e-1e0d98ef7f30/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
             "2:cpu:/docker-ce/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
             "2:cpu:/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b/user/jenkins/0",
-            "/kubepods/burstable/pod1fe52ba4-5709-11ea-9ee3-00505682780f/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b/user.slice"
+            "11:pids:/kubepods/burstable/pod1fe52ba4-5709-11ea-9ee3-00505682780f/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b/user.slice"
         };
 
         for (final String possibleCgroupString : possibleCgroupStrings) {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroupTest.java
@@ -23,7 +23,8 @@ public class ControlGroupTest {
             "8:cpuset:/kubepods.slice/kubepods-pod9c26dfb6_b9c9_11e7_bfb9_02c6c1fc4861.slice/docker-3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b.scope",
             "8:cpuset:/kubepods/besteffort/pod60070ae4-c63a-11e7-92b3-0adc1ac11520/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
             "7:cpu:/ecs/0410eff2-7e59-4111-823e-1e0d98ef7f30/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
-            "2:cpu:/docker-ce/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b"
+            "2:cpu:/docker-ce/docker/3dd988081e7149463c043b5d9c57d7309e079c5e9290f91feba1cc45a04d6a5b",
+            "/kubepods/burstable/pod1fe52ba4-5709-11ea-9ee3-00505682780f/d65c8853fa45d139ce95d5c2b68a6e4aa8da83894d8eb0396cd6edd1c134c97c/us    er.slice"
         };
 
         for (final String possibleCgroupString : possibleCgroupStrings) {


### PR DESCRIPTION
Bugfix for JENKINS-57129
java.io.IOException: 
Unexpected cgroup syntax, https://issues.jenkins-ci.org/browse/JENKINS-57129

The old parser is not universal and does not take in account some variants like this:
/kubepods/burstable/pod1fe52ba4-5709-11ea-9ee3-00505682780f/d65c8853fa45d139ce95d5c2b68a6e4aa8da83894d8eb0396cd6edd1c134c97c/user.slice
