### PR TITLE
✨ feat(docker): not dettach when docker run has --attach as argument

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -137,7 +137,8 @@ class Docker implements Serializable {
 
         public Container run(String args = '', String command = "") {
             docker.node {
-                def container = docker.script."${docker.shell()}"(script: "docker run -d${args != '' ? ' ' + args : ''} ${id}${command != '' ? ' ' + command : ''}", returnStdout: true).trim()
+                def shouldUseDetach = !args.contains(' -a') && !args.contains("--attach")
+                def container = docker.script."${docker.shell()}"(script: "docker run ${shouldUseDetach? -d : ''}${args != '' ? ' ' + args : ''} ${id}${command != '' ? ' ' + command : ''}", returnStdout: true).trim()
                 new Container(docker, container)
             }
         }


### PR DESCRIPTION
## 📖 Description
To give the option to the user to attach to a docker image and bypass `detach` option set as default by `.withRun()` and `.run()` for Docker plugin:

https://github.com/jenkinsci/docker-workflow-plugin/blob/e146e951a37e04288a92f8716e6130757b04f4c1/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy#L138-L140

---

⚠️ I did not find a `CONTRIBUTING.md` or similar place where to follow guidelines so... if I did something wrong or needs change, please let me know and I will be happy to apply it :)

