### PR TITLE
DockerClient.version() falls back to trying '--version' 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -251,9 +251,12 @@ public class DockerClient {
         LaunchResult result = launch(new EnvVars(), true, "-v");
         if (result.getStatus() == 0) {
             return parseVersionNumber(result.getOut());
-        } else {
-            return null;
         }
+        result = launch(new EnvVars(), true, "--version");
+        if (result.getStatus() == 0) {
+            return parseVersionNumber(result.getOut());
+        }
+        return null;
     }
     
     private static final Pattern pattern = Pattern.compile("^(\\D+)(\\d+)\\.(\\d+)\\.(\\d+)(.*)");


### PR DESCRIPTION
Hello.

As far as I can tell, only '-v' option is used to determine the docker version.

I added a fallback to check again for '--version', since I'm trying to make this run with podman instead of docker. Podman does not support the '-v' flag.

Best,
Renat