### PR TITLE
2.164.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.40</version>
+        <version>3.57</version>
         <relativePath />
     </parent>
     <artifactId>docker-workflow</artifactId>
@@ -31,7 +31,7 @@
     <properties>
         <revision>1.24</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.150.3</jenkins.version>
+        <jenkins.version>2.164.3</jenkins.version>
         <java.level>8</java.level>
         <pipeline-model-definition-plugin.version>1.5.1</pipeline-model-definition-plugin.version>
     </properties>
@@ -51,8 +51,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.150.x</artifactId>
-                <version>5</version>
+                <artifactId>bom-2.164.x</artifactId>
+                <version>9</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
As of https://github.com/jenkinsci/bom/pull/222 the BOM no longer supports 2.150.x, which was obsoleted 13 months ago with the [release of 2.164.x](https://jenkins.io/changelog-stable/#v2.164.1); the update center only promises to support the last five lines.