### PR TITLE
Remove section header from folder properties in jelly.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/FolderConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/FolderConfig/config.groovy
@@ -28,9 +28,7 @@ package org.jenkinsci.plugins.docker.workflow.declarative.FolderConfig
 
 def f = namespace(lib.FormTagLib)
 
-f.section(title:_("Declarative Pipeline (Docker)")) {
-    f.entry(field: "dockerLabel", title: _("Docker Label")) {
-        f.textbox()
-    }
-    f.property(field: "registry")
+f.entry(field: "dockerLabel", title: _("Docker Label")) {
+    f.textbox()
 }
+f.property(field: "registry")

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig/config.groovy
@@ -28,7 +28,9 @@ package org.jenkinsci.plugins.docker.workflow.declarative.GlobalConfig
 
 def f = namespace(lib.FormTagLib)
 
-f.entry(field: "dockerLabel", title:_("Docker Label")) {
-    f.textbox()
+f.section(title:_("Declarative Pipeline (Docker)")) {
+    f.entry(field: "dockerLabel", title:_("Docker Label")) {
+        f.textbox()
+    }
+    f.property(field: "registry")
 }
-f.property(field: "registry")

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig/config.groovy
@@ -28,9 +28,7 @@ package org.jenkinsci.plugins.docker.workflow.declarative.GlobalConfig
 
 def f = namespace(lib.FormTagLib)
 
-f.section(title:_("Declarative Pipeline (Docker)")) {
-    f.entry(field: "dockerLabel", title:_("Docker Label")) {
-        f.textbox()
-    }
-    f.property(field: "registry")
+f.entry(field: "dockerLabel", title:_("Docker Label")) {
+    f.textbox()
 }
+f.property(field: "registry")


### PR DESCRIPTION
The section header `Declarative Pipeline (Docker)` in the UI can cause the properties folder to render incorrectly when other plugins are installed.

CC @dwnusbaum 