### PR TITLE
JENKINS-52264 The variable "=" is removed when the exec command is executed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -286,10 +286,11 @@ public class WithContainerStep extends AbstractStepImpl {
                     Set<String> envReduced = new TreeSet<String>(Arrays.asList(starter.envs()));
                     envReduced.removeAll(Arrays.asList(envHost));
 
-                    // Remove PATH during `exec` as well.
+                    // Remove PATH or invalid variable during `exec` as well.
                     Iterator<String> it = envReduced.iterator();
                     while (it.hasNext()) {
-                        if (it.next().startsWith("PATH=")) {
+                        final String envVar = it.next();
+                        if (envVar.startsWith("PATH=") || "=".equals(envVar.trim())) {
                             it.remove();
                         }
                     }


### PR DESCRIPTION
This PR contains a change to remove the variable "=" when the plugin executes the _exec_ command.

This problem appears after executing a sh command inside the withDockerContainer block. Activate the diagnosis and the error was:

```
invalid argument "=" for "-e, --env" flag: invalid environment variable: =
See 'docker exec --help'.
```

Also, I activated the class Logger and found the empty variable from message _FINE org.jenkinsci.plugins.docker.workflow.WithContainerStep (exec) reduced environment: [**=**,....]_.

I was looking for information about this and found a PR #101 that fixed a similar problem but for the run command.

For now I am using as an alternative to run the withDockerContainer function with a withEnv to override the invalid environment variable. For example:

```groovy
withEnv(['=']) {
    withDockerContainer(/* arguments */) {
      // some steps
    }
}
```

I understand it's an issue that Jenkins allows empty variables from the global variables section, but I think it would be a good idea to add this change to make the plugin more tolerant to such situations.
