### PR TITLE
escape double quotes in env variables under windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <revision>1.25</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.176.4</jenkins.version>
+        <jenkins.version>2.190.1</jenkins.version>
         <java.level>8</java.level>
         <pipeline-model-definition-plugin.version>1.5.1</pipeline-model-definition-plugin.version>
     </properties>
@@ -51,7 +51,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.176.x</artifactId>
+                <artifactId>bom-2.190.x</artifactId>
                 <version>11</version>
                 <scope>import</scope>
                 <type>pom</type>

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
@@ -5,6 +5,7 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Node;
+import hudson.os.WindowsUtil;
 import hudson.util.ArgumentListBuilder;
 
 import javax.annotation.CheckForNull;
@@ -46,7 +47,7 @@ public class WindowsDockerClient extends DockerClient {
         }
         for (Map.Entry<String, String> variable : containerEnv.entrySet()) {
             argb.add("-e");
-            argb.addMasked(variable.getKey()+"="+variable.getValue());
+            argb.addMasked(WindowsUtil.quoteArgument(variable.getKey() + "=" + variable.getValue()));
         }
         argb.add(image).add(command);
 


### PR DESCRIPTION
**Problem description:**
For Windows there is a problem with Javas ProcessBuilder and arguments that contain spaces and contain double quotes as ProcessBuilder adds double quotes around such argument.
See e.g. https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6511002 and https://stackoverflow.com/questions/12124935/processbuilder-adds-extra-quotes-to-command-line

**Solution:**
For Windows all environment variables (only values) are escaped (currently only escapes quotes). No changes made to the Linux (and others) code as I could only reproduce this behavior with a Windows node.

**Notes:**
- This is nearly the same as #215 but does not add additional quotes around every environment variable value and also applies this do Windows only.
- I build this changes locally and tested it in some Jenkins test instance and for my minimal testcases it resolved the issue and did not introduce new issues.