### PR TITLE
Better support for windows dockers in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
 buildPlugin(platforms: [
-    'linux'
+    'linux',
+    'windows'
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,3 @@
 buildPlugin(platforms: [
-    'linux',
-    'windows && !windock' // TODO Docker-based tests fail on 2019
+    'linux'
 ])

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -35,6 +35,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,6 +56,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
 public class DockerDSLTest {
+
+    @BeforeClass
+    public static void unix() throws Exception {
+        DockerTestUtil.assumeNotWindows();
+    }
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStepTest.java
@@ -33,6 +33,7 @@ import org.jenkinsci.plugins.docker.workflow.client.DockerClient;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
@@ -42,6 +43,12 @@ import static org.jenkinsci.plugins.docker.workflow.DockerTestUtil.assumeDocker;
 import static org.junit.Assert.assertNotNull;
 
 public class FromFingerprintStepTest {
+
+    @BeforeClass
+    public static void unix() throws Exception {
+        DockerTestUtil.assumeNotWindows();
+    }
+
     @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
 
     private static final String BUSYBOX_IMAGE = "quay.io/prometheus/busybox:latest";

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -65,6 +65,7 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -78,7 +79,14 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import static org.junit.Assume.assumeTrue;
+
 public class WithContainerStepTest {
+
+    @BeforeClass
+    public static void unix() throws Exception {
+        assumeTrue("This test is only for Unix", File.pathSeparatorChar==':');
+    }
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -386,22 +386,4 @@ public class WithContainerStepTest {
             }
         }
     }
-
-    @Issue("JENKINS-52264")
-    @Test public void emptyEnv() {
-        story.then(r -> {
-            DockerTestUtil.assumeDocker();
-            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-            p.setDefinition(new CpsFlowDefinition(
-                "node {\n" +
-                    "  withEnv(['=']) {\n" +
-                    "    withDockerContainer('ubuntu') {\n" +
-                    "      sh 'pwd'\n" +
-                    "    }\n" +
-                    "  }\n" +
-                    "}", true));
-            WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-//            story.j.assertLogNotContains("hello from some step", b);
-        });
-    }
 }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -85,7 +85,7 @@ public class WithContainerStepTest {
 
     @BeforeClass
     public static void unix() throws Exception {
-        assumeTrue("This test is only for Unix", File.pathSeparatorChar==':');
+        DockerTestUtil.assumeNotWindows();
     }
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -387,4 +387,21 @@ public class WithContainerStepTest {
         }
     }
 
+    @Issue("JENKINS-52264")
+    @Test public void emptyEnv() {
+        story.then(r -> {
+            DockerTestUtil.assumeDocker();
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition(
+                "node {\n" +
+                    "  withEnv(['=']) {\n" +
+                    "    withDockerContainer('ubuntu') {\n" +
+                    "      sh 'pwd'\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}", true));
+            WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+//            story.j.assertLogNotContains("hello from some step", b);
+        });
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -79,8 +79,6 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import static org.junit.Assume.assumeTrue;
-
 public class WithContainerStepTest {
 
     @BeforeClass

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
@@ -32,6 +32,7 @@ import hudson.util.VersionNumber;
 import org.jenkinsci.plugins.docker.commons.fingerprint.ContainerRecord;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -43,6 +44,11 @@ import java.util.Collections;
 public class DockerClientTest {
 
     private DockerClient dockerClient;
+
+    @BeforeClass
+    public static void unix() throws Exception {
+        DockerTestUtil.assumeNotWindows();
+    }
     
     @Before
     public void setup() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtilsTest.java
@@ -58,6 +58,7 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setup() throws Exception {
+        DockerTestUtil.assumeNotWindows();
         CredentialsStore store = CredentialsProvider.lookupStores(j.jenkins).iterator().next();
 
         store.addCredentials(Domain.global(), globalCred);

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerAgentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerAgentTest.java
@@ -55,6 +55,7 @@ public class DockerAgentTest extends AbstractModelDefTest {
     private static String password;
     @BeforeClass
     public static void setUpAgent() throws Exception {
+        DockerTestUtil.assumeNotWindows();
         s = j.createOnlineSlave();
         s.setLabelString("some-label docker");
         s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true"),

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerPostStageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerPostStageTest.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.docker.workflow.declarative;
 
 import org.jenkinsci.plugins.docker.workflow.DockerTestUtil;
 import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -33,6 +34,11 @@ import org.jvnet.hudson.test.Issue;
  * Adapted from {@link org.jenkinsci.plugins.pipeline.modeldefinition.PostStageTest}.
  */
 public class DockerPostStageTest extends AbstractModelDefTest {
+
+    @BeforeClass
+    public static void unix() throws Exception {
+        DockerTestUtil.assumeNotWindows();
+    }
 
     @Issue("JENKINS-46276")
     @Test


### PR DESCRIPTION
CI is getting held up on the buildPlugin() condition `windows&&!windock'.