### PR TITLE
Potential fix for JENKINS-63628 and JENKINS-57452

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -73,6 +73,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class WithContainerStep extends AbstractStepImpl {
     
     private static final Logger LOGGER = Logger.getLogger(WithContainerStep.class.getName());
@@ -196,6 +199,13 @@ public class WithContainerStep extends AbstractStepImpl {
 
             String command = launcher.isUnix() ? "cat" : "cmd.exe";
             container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ command);
+            Pattern cid_rx = Pattern.compile("[0-9,a-f]{64}");
+            Matcher cid_mr = cid_rx.matcher(container);
+            
+            if (cid_mr.find()) {
+                container = cid_mr.group();
+            }
+
             final List<String> ps = dockerClient.listProcess(env, container);
             if (!ps.contains(command)) {
                 listener.error(


### PR DESCRIPTION
Following the linked issues, we are looking for a solution to capture only docker container Id after executing 'docker run' command. In the linked issues (for JENKINS-57452 ,please look at the Comments) you can see that sometimes, additional messages written on the output stream of 'docker run' command are captured in addition to container Id ,and this breaks further 'docker top' command and fails the build/stage.
We propose to use regex - [0-9,a-f]{64} ,to capture docker container Id and exclude additional messages.