### PR TITLE
[JENKINS-53866] Ability to specify imageName to tag and push

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -153,19 +153,19 @@ class Docker implements Serializable {
             }
         }
 
-        public void tag(String tagName = parsedId.tag, boolean force = true) {
+        public void tag(String tagName = parsedId.tag, boolean force = true, String imageName = parsedId.userAndRepo) {
             docker.node {
-                def taggedImageName = toQualifiedImageName(parsedId.userAndRepo + ':' + tagName)
+                def taggedImageName = toQualifiedImageName(imageName + ':' + tagName)
                 docker.script."${docker.shell()}" "docker tag ${id} ${taggedImageName}"
                 return taggedImageName;
             }
         }
 
-        public void push(String tagName = parsedId.tag, boolean force = true) {
+        public void push(String tagName = parsedId.tag, boolean force = true, String imageName = parsedId.userAndRepo) {
             docker.node {
                 // The image may have already been tagged, so the tagging may be a no-op.
                 // That's ok since tagging is cheap.
-                def taggedImageName = tag(tagName, force)
+                def taggedImageName = tag(tagName, force, imageName)
                 docker.script."${docker.shell()}" "docker push ${taggedImageName}"
             }
         }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -355,13 +355,19 @@ public class DockerDSLTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +
-                    "     try { sh 'docker rmi busybox:test' } catch (Exception e) {}\n" +
+                    "     try { sh 'docker rmi busybox:test my.registry.com/busybox:test' } catch (Exception e) {}\n" +
                     "     def busybox = docker.image('busybox');\n" +
                     "     busybox.pull();\n" +
                     "     // tag it\n" +
                     "     busybox.tag('test', /* ignored but to test that the argument is accepted */false);\n" +
+                    "     // assert that the tag exists\n" +
+                    "     sh 'docker inspect busybox:test'\n" +    
                     "     // retag it\n" +
-                    "     busybox.tag('test');\n" +
+                    "     busybox.tag('test');\n" + 
+                    "     // retag it with new image name\n" +
+                    "     busybox.tag('test', /* ignored but to test that the argument is accepted */ false, 'my.registry.com/busybox');\n" + 
+                    "     // assert that the tag exists\n" + 
+                    "     sh 'docker inspect my.registry.com/busybox:test'\n" +
                     "}", true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             }


### PR DESCRIPTION
[JENKINS-53866](https://issues.jenkins-ci.org/browse/JENKINS-53866) Provide the ability to modify the image qualified name through the `docker.tag` and `docker.push` function.