### PR TITLE
Remove anonymous volumes on stop

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -183,7 +183,7 @@ class Docker implements Serializable {
         }
 
         public void stop() {
-            docker.script."${docker.shell()}" "docker stop ${id} && docker rm -f ${id}"
+            docker.script."${docker.shell()}" "docker stop ${id} && docker rm -fv ${id}"
         }
 
         public String port(int port) {


### PR DESCRIPTION
This PR makes the Docker Pipeline Plugin to remove any anonymous volumes on container stop by appending the "-v" flag on the "docker rm" command.

Some Dockerfiles that run on my pipelines have the [VOLUME instruction](https://docs.docker.com/engine/reference/builder/#volume), so those volumes are staying in the system if they are not defined during container invocation / stay anonymous.