### PR TITLE
Pass --cgroup-parent to docker run when the root agent is a container

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -194,8 +194,10 @@ public class WithContainerStep extends AbstractStepImpl {
                 volumes.put(tmp, tmp);
             }
 
+            // Inherit from the parent container's cgroup (if any).
+            Optional<String> cgroup = dockerClient.getCgroupIfContainerized();
             String command = launcher.isUnix() ? "cat" : "cmd.exe";
-            container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ command);
+            container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), cgroup, /* expected to hang until killed */ command);
             final List<String> ps = dockerClient.listProcess(env, container);
             if (!ps.contains(command)) {
                 listener.error(

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -194,8 +194,12 @@ public class WithContainerStep extends AbstractStepImpl {
                 volumes.put(tmp, tmp);
             }
 
-            // Inherit from the parent container's cgroup (if any).
-            Optional<String> cgroup = dockerClient.getCgroupIfContainerized();
+            Optional<String> cgroup = Optional.absent();
+            Boolean inheritCgroup = !Boolean.getBoolean(WithContainerStep.class.getName()+".NO_INHERIT_CGROUP");
+            if (inheritCgroup) {
+                // Inherit from the parent container's cgroup (if any).
+                cgroup = dockerClient.getCgroupIfContainerized();
+            }
             String command = launcher.isUnix() ? "cat" : "cmd.exe";
             container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), cgroup, /* expected to hang until killed */ command);
             final List<String> ps = dockerClient.listProcess(env, container);

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
@@ -81,4 +81,18 @@ public class ControlGroup {
         return containerId;
     }
 
+    public static Optional<String> getCgroup(FilePath procfile) throws IOException, InterruptedException {
+        return getCgroup(new InputStreamReader(procfile.read(), StandardCharsets.UTF_8));
+    }
+
+    static Optional<String> getCgroup(Reader reader) throws IOException {
+        try (BufferedReader r = new BufferedReader(reader)) {
+            String line;
+            while ((line = r.readLine()) != null) {
+                final ControlGroup cgroup = new ControlGroup(line);
+                return Optional.of(cgroup.group);
+            }
+        }
+        return Optional.absent();
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
@@ -29,7 +29,7 @@ public class WindowsDockerClient extends DockerClient {
     }
 
     @Override
-    public String run(@Nonnull EnvVars launchEnv, @Nonnull String image, @CheckForNull String args, @CheckForNull String workdir, @Nonnull Map<String, String> volumes, @Nonnull Collection<String> volumesFromContainers, @Nonnull EnvVars containerEnv, @Nonnull String user, @Nonnull String... command) throws IOException, InterruptedException {
+    public String run(@Nonnull EnvVars launchEnv, @Nonnull String image, @CheckForNull String args, @CheckForNull String workdir, @Nonnull Map<String, String> volumes, @Nonnull Collection<String> volumesFromContainers, @Nonnull EnvVars containerEnv, @Nonnull String user, Optional<String> cgroupParent, @Nonnull String... command) throws IOException, InterruptedException {
         ArgumentListBuilder argb = new ArgumentListBuilder("docker", "run", "-d", "-t");
         if (args != null) {
             argb.addTokenized(args);
@@ -43,6 +43,9 @@ public class WindowsDockerClient extends DockerClient {
         }
         for (String containerId : volumesFromContainers) {
             argb.add("--volumes-from", containerId);
+        }
+        if (cgroupParent.isPresent()) {
+            argb.add("--cgroup-parent", cgroupParent.get());
         }
         for (Map.Entry<String, String> variable : containerEnv.entrySet()) {
             argb.add("-e");

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.docker.workflow.client;
 
+import com.google.common.base.Optional;
 import org.jenkinsci.plugins.docker.workflow.DockerTestUtil;
 import hudson.EnvVars;
 import hudson.Launcher;
@@ -59,8 +60,8 @@ public class DockerClientTest {
     public void test_run() throws IOException, InterruptedException {
         EnvVars launchEnv = DockerTestUtil.newDockerLaunchEnv();
         String containerId =
-                dockerClient.run(launchEnv, "learn/tutorial", null, null, Collections.<String, String>emptyMap(), Collections.<String>emptyList(), new EnvVars(),
-                        dockerClient.whoAmI(), "cat");
+            dockerClient.run(launchEnv, "learn/tutorial", null, null, Collections.<String, String>emptyMap(), Collections.<String>emptyList(), new EnvVars(),
+                        dockerClient.whoAmI(), Optional.<String>absent(), "cat");
         Assert.assertEquals(64, containerId.length());
         ContainerRecord containerRecord = dockerClient.getContainerRecord(launchEnv, containerId);
         Assert.assertEquals(dockerClient.inspect(launchEnv, "learn/tutorial", ".Id"), containerRecord.getImageId());

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClientTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.docker.workflow.client;
 
+import com.google.common.base.Optional;
 import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.TaskListener;
@@ -39,6 +40,7 @@ public class WindowsDockerClientTest {
             Collections.emptyList(),
             new EnvVars(),
             dockerClient.whoAmI(),
+            Optional.absent(),
             "cat");
 
         Assert.assertEquals(64, containerId.length());


### PR DESCRIPTION
Our root agent is a kubernetes pod template and we're using the docker workflow plugin to spawn containers for steps with specific image requirements.  Since --cgroup-parent is not being used these containers don't get tracked as part of the pod.  We believe this may be causing some resource issues on our kubernetes nodes and also circumvents any metrics collected for the pod.

This change passes --cgroup-parent=<cgroup> to docker run when the plugin notices that the root agent is a container.  The spawned containers are then tracked under the cgroup for the jnlp container in the pod.  This new behavior can be turned off with a system property.