### PR TITLE
Fix: Distroless containers do not have a path - sponsored by SDA SE

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -194,7 +194,7 @@ public class WithContainerStep extends AbstractStepImpl {
                 volumes.put(tmp, tmp);
             }
 
-            String command = launcher.isUnix() ? "cat" : "cmd.exe";
+            String command = launcher.isUnix() ? "/bin/cat" : "cmd.exe";
             container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ command);
             final List<String> ps = dockerClient.listProcess(env, container);
             if (!ps.contains(command)) {


### PR DESCRIPTION
By using distroless containers, we try to remove as much as possible. Therefore, no bash/sh/$PATH is there.
To be able to run distroless-image in the pipeline, the absolute path would be helpful.