### PR TITLE
JENKINS-64608: detect running in container by ENV to allow detection independent of cgroup version

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/ControlGroup.java
@@ -8,8 +8,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -35,6 +33,19 @@ public class ControlGroup {
         group = fields[2];
     }
 
+    public static Optional<String> getContainerIdByHostname(FilePath hostnameFile) throws IOException, InterruptedException {
+        return getContainerIdByHostname(new InputStreamReader(hostnameFile.read(), StandardCharsets.UTF_8));
+    }
+
+    static Optional<String> getContainerIdByHostname(Reader reader) throws IOException {
+        try (BufferedReader r = new BufferedReader(reader)) {
+            String line;
+            if ((line = r.readLine()) != null) {
+                return Optional.of(line.trim());
+            }
+        }
+        return Optional.absent();
+    }
 
     public static Optional<String> getContainerId(FilePath procfile) throws IOException, InterruptedException {
         return getContainerId(new InputStreamReader(procfile.read(), StandardCharsets.UTF_8));

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -345,17 +345,22 @@ public class DockerClient {
      * @see <a href="http://stackoverflow.com/a/25729598/12916">Discussion</a>
      */
     public Optional<String> getContainerIdIfContainerized() throws IOException, InterruptedException {
+        if (node == null) {
+            return Optional.absent();
+        }
         if ("true".equals(System.getenv("JENKINS_RUNNING_IN_CONTAINER"))) {
-            if (node == null) {
-                return Optional.absent();
-            }
             FilePath hostnameFile = node.createPath("/etc/hostname");
             if (hostnameFile == null || !hostnameFile.exists()) {
                 return Optional.absent();
             }
             return ControlGroup.getContainerIdByHostname(hostnameFile);
+        } else {
+            FilePath cgroupFile = node.createPath("/proc/self/cgroup");
+            if (cgroupFile == null || !cgroupFile.exists()) {
+                return Optional.absent();
+            }
+            return ControlGroup.getContainerId(cgroupFile);
         }
-        return Optional.absent();
     }
 
     public ContainerRecord getContainerRecord(@Nonnull EnvVars launchEnv, String containerId) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -345,14 +345,17 @@ public class DockerClient {
      * @see <a href="http://stackoverflow.com/a/25729598/12916">Discussion</a>
      */
     public Optional<String> getContainerIdIfContainerized() throws IOException, InterruptedException {
-        if (node == null) {
-            return Optional.absent();
+        if ("true".equals(System.getenv("JENKINS_RUNNING_IN_CONTAINER"))) {
+            if (node == null) {
+                return Optional.absent();
+            }
+            FilePath hostnameFile = node.createPath("/etc/hostname");
+            if (hostnameFile == null || !hostnameFile.exists()) {
+                return Optional.absent();
+            }
+            return ControlGroup.getContainerIdByHostname(hostnameFile);
         }
-        FilePath cgroupFile = node.createPath("/proc/self/cgroup");
-        if (cgroupFile == null || !cgroupFile.exists()) {
-            return Optional.absent();
-        }
-        return ControlGroup.getContainerId(cgroupFile);
+        return Optional.absent();
     }
 
     public ContainerRecord getContainerRecord(@Nonnull EnvVars launchEnv, String containerId) throws IOException, InterruptedException {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
When using **cgroup v2** the docker-workflow-plugin cannot determine if it is running inside a container by checking `/proc/self/cgroup` anymore.

**JIRA:** https://issues.jenkins.io/browse/JENKINS-64608

I suggest using an environment variable telling the plugin if Jenkins is running inside a container, so we are independent of cgroup version. I called the env var `JENKINS_RUNNING_IN_CONTAINER` which has to be set to `true`. This could be done in Jenkins' Dockerfile, so no configuration has to be changed for example in docker-compose or kubernetes. The container ID is resolved by taking a look into `/etc/hostname`, which is only giving the short container id, it can be discussed if that could face a problem.

Before I provide tests I would like to get some feedback if the general idea is okay or not.

Background
----------
I recently updated to Debian 11 (providing cgroup v2 support) which broke my Jenkins setup, so I quickly needed a fix. I am using this patched plugin right now in my personal Jenkins and it is working perfectly fine.

Addendum
--------
Here the question is asked how to obtain docker info when cgroup v2 is enabled, still unanswered:
https://stackoverflow.com/questions/68816329/how-to-get-docker-container-id-from-within-the-container-with-cgroup-v2

Checklist
---------
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
