### PR TITLE
Allow to run docker image with argument -u

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -116,7 +116,9 @@ public class DockerClient {
         argb.add("run", "-t", "-d");
 
         // Username might be empty because we are running on Windows
-        if (StringUtils.isNotEmpty(user)) {
+        // or user and group id is given in arguments
+        boolean isUserGiven = (args != null && args.contains("-u "));
+        if (StringUtils.isNotEmpty(user) && !isUserGiven) {
             argb.add("-u", user);
         }
         if (args != null) {


### PR DESCRIPTION
Current State:
*JenkinsSshUsr* -> admin user, allowed to run docker command on node.
*TstUsr* -> testuser, which has access to the display but no permissions for f.e. docker commands
The docker container is currently build and run with the *JenkinsSshUsr* user.

You can build the image with the *JenkinsSshUsr* user, but our dockerfile has two parameters to configure the users inside the container (UID and GID). Here you can give him the *TstUsr* to work with.
Then you can run the image with the following parameter: "-u *TstUsr*:*TstUsr*". That way you start the docker command with the *JenkinsSshUsr*, which has the correct permissions, but inside the docker the *TstUsr* runs, which has permissions for the display.
Problem: The jenkins function, which comes with the docker plugin has a built in functionality which uses automatically the user, which was used to run the command.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
Check if given docker run arguments contains option -u and ignore whoami in that case
- [ x] Link to relevant issues in GitHub or Jira
closes https://issues.jenkins.io/browse/JENKINS-49437
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
