### PR TITLE
[JENKINS-64751] Quote "docker exec" env-vars on Windows

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -37,6 +37,7 @@ import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.os.WindowsUtil;
 import hudson.slaves.WorkspaceList;
 import hudson.util.VersionNumber;
 import java.util.ArrayList;
@@ -299,7 +300,11 @@ public class WithContainerStep extends AbstractStepImpl {
                         for (String e : envReduced) {
                             prefix.add("--env");
                             masksPrefixList.add(false);
-                            prefix.add(e);
+                            if (super.isUnix()) {
+                                prefix.add(e);
+                            } else {
+                                prefix.add(WindowsUtil.quoteArgument(e));
+                            }
                             masksPrefixList.add(true);
                         }
                         prefix.add(container);
@@ -309,7 +314,13 @@ public class WithContainerStep extends AbstractStepImpl {
                         masksPrefixList.add(false);
                         prefix.add("env");
                         masksPrefixList.add(false);
-                        prefix.addAll(envReduced);
+                        if (super.isUnix()) {
+                            prefix.addAll(envReduced);
+                        } else {
+                            prefix.addAll(envReduced.stream()
+                                                    .map(v -> WindowsUtil.quoteArgument(v))
+                                                    .collect(Collectors.toList()));
+                        }
                         masksPrefixList.addAll(envReduced.stream()
                                                          .map(v -> true)
                                                          .collect(Collectors.toList()));


### PR DESCRIPTION
Based on c97bf2305ccf8c8dc1fcc91e329bf81a41c14638 from #220 which quoted "docker run" env-vars, this addresses [JENKINS-64751](https://issues.jenkins.io/browse/JENKINS-64751) and [JENKINS-65933](https://issues.jenkins.io/browse/JENKINS-65933).

I have not included any tests, as my understanding from #215 is that we do not have test infrastructure that supports docker-execution tests on Windows, similarly to #220.

- [x] Draft because:
  - [ ] I wanted initial CI results from Jenkins
  - [x] I need to test this with the reproduction case in the comments of [JENKINS-64751](https://issues.jenkins.io/browse/JENKINS-64751)
  - [x] I need to get local sign-off due to employer requirements.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
