### PR TITLE
Add escape hatch back to v. 1.26 behavior

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerDSL.java
@@ -25,13 +25,23 @@ package org.jenkinsci.plugins.docker.workflow;
 
 import groovy.lang.Binding;
 import hudson.Extension;
+import jenkins.util.SystemProperties;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
+
+import java.util.logging.Logger;
 
 /**
  * Something you should <strong>not copy</strong>. Write plain old {@code Step}s and leave it at that.
  */
 @Extension public class DockerDSL extends GlobalVariable {
+
+    /**
+     * Escape hatch to restore the old parameter behaviour in <code>docker</code> to &lt;= 1.26 state.
+     * Except {@link org.jenkinsci.plugins.docker.commons.credentials.ImageNameValidator#checkUserAndRepo(String)}
+     * will still be checked unless it is also bypassed with {@link org.jenkinsci.plugins.docker.commons.credentials.ImageNameValidator#SKIP}.
+     */
+    /*package*/ static /*almost final*/ boolean UNSAFE_PARAMETER_EXPANDING = Boolean.getBoolean(DockerDSL.class.getName() + ".UNSAFE_PARAMETER_EXPANDING");
 
     @Override public String getName() {
         return "docker";
@@ -48,6 +58,15 @@ import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
             binding.setVariable(getName(), docker);
         }
         return docker;
+    }
+
+    private static final Logger log = Logger.getLogger(DockerDSL.class.getName());
+
+    public static boolean isUnsafeParameterExpanding() {
+        if (UNSAFE_PARAMETER_EXPANDING) {
+            log.fine("WARNING! Unsafe parameter expansion is enabled. (legacy mode)");
+        }
+        return UNSAFE_PARAMETER_EXPANDING;
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerTestUtil.java
@@ -30,7 +30,13 @@ import hudson.util.StreamTaskListener;
 import hudson.util.VersionNumber;
 import org.junit.Assume;
 
+import java.io.Closeable;
 import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.jenkinsci.plugins.docker.commons.tools.DockerTool;
@@ -82,6 +88,31 @@ public class DockerTestUtil {
             env.put("DOCKER_CERT_PATH", docker_host_key_dir_for_test);
         }
         return env;
+    }
+
+    /**
+     * TODO There is still a slight risk here that two JVMs in parallel could pick the same random port.
+     * @return a random, currently free, tcp port
+     */
+    public static int randomTcpPort(){
+        final int from = 49152;
+        final int to = 65535;
+
+
+        while(true){
+            int candidate = (int) ((Math.random() * (to-from)) + from);
+            if(isTcpPortFree(candidate)){
+                return candidate;
+            }
+        }
+    }
+
+    public static boolean isTcpPortFree(int port){
+        try (ServerSocket ignored = new ServerSocket(port)) {
+            return true;
+        } catch (IOException ex) {
+            return false;
+        }
     }
 
     private DockerTestUtil() {}


### PR DESCRIPTION
Docker Pipeline [v. 1.27](https://github.com/jenkinsci/docker-workflow-plugin/releases/tag/docker-workflow-1.27) introduced a new way of interpolating parameters to the methods of the Docker DSL.
This adds an escape hatch to restore the interpolation to how it unsafely behaved in 1.26 and earlier.
Set `org.jenkinsci.plugins.docker.workflow.DockerDSL.UNSAFE_PARAMETER_EXPANDING=true` to activate the escape hatch.

The image name validation introduced in [Docker Commons v.1.18](https://github.com/jenkinsci/docker-commons-plugin/releases/tag/docker-commons-1.18) is still intact when setting this escape hatch and still needs to be activated as normal with `org.jenkinsci.plugins.docker.commons.credentials.ImageNameValidator.SKIP=true`.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
