### PR TITLE
Use GroovySourceFileAllowlist to adapt to SECURITY-359 changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.332.1</jenkins.version>
         <java.level>8</java.level>
-        <pipeline-model-definition-plugin.version>2.2083.ve1feea_c84e37</pipeline-model-definition-plugin.version> <!-- TODO: https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/529 --> <!-- TODO: Delete this and related dependencyManagement entries once this version is included in BOM -->
+        <pipeline-model-definition-plugin.version>2.2091.v778707d02a_a_a_</pipeline-model-definition-plugin.version> <!-- TODO: https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/529 --> <!-- TODO: Delete this and related dependencyManagement entries once this version is included in BOM -->
         <workflow-cps-plugin.version>2699.v7231c3b_4a_231</workflow-cps-plugin.version> <!-- TODO: https://github.com/jenkinsci/workflow-cps-plugin/pull/538 -->
     </properties>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.332.1</jenkins.version>
         <java.level>8</java.level>
-        <pipeline-model-definition-plugin.version>2.2091.v778707d02a_a_a_</pipeline-model-definition-plugin.version> <!-- TODO: https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/529 --> <!-- TODO: Delete this and related dependencyManagement entries once this version is included in BOM -->
-        <workflow-cps-plugin.version>2699.v7231c3b_4a_231</workflow-cps-plugin.version> <!-- TODO: https://github.com/jenkinsci/workflow-cps-plugin/pull/538 -->
+        <pipeline-model-definition-plugin.version>2.2097.v33db_b_de764b_e</pipeline-model-definition-plugin.version> <!-- TODO: Delete this and related dependencyManagement entries once this version is included in BOM -->
     </properties>
     <repositories>
         <repository>
@@ -53,15 +52,9 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.332.x</artifactId>
-                <version>1382.v7d694476f340</version>
+                <version>1409.v7659b_c072f18</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <!-- TODO: Remove once this version is included in BOM -->
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>script-security</artifactId>
-                <version>1172.v35f6a_0b_8207e</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkinsci.plugins</groupId>
@@ -89,7 +82,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow-cps-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -122,7 +114,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow-cps-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,10 @@
     <properties>
         <revision>1.29</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.222.4</jenkins.version>
+        <jenkins.version>2.332.1</jenkins.version>
         <java.level>8</java.level>
-        <pipeline-model-definition-plugin.version>1.8.1</pipeline-model-definition-plugin.version>
+        <pipeline-model-definition-plugin.version>2.2083.ve1feea_c84e37</pipeline-model-definition-plugin.version> <!-- TODO: https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/529 --> <!-- TODO: Delete this and related dependencyManagement entries once this version is included in BOM -->
+        <workflow-cps-plugin.version>2699.v7231c3b_4a_231</workflow-cps-plugin.version> <!-- TODO: https://github.com/jenkinsci/workflow-cps-plugin/pull/538 -->
     </properties>
     <repositories>
         <repository>
@@ -51,12 +52,32 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.222.x</artifactId>
-                <version>887.vae9c8ac09ff7</version>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1382.v7d694476f340</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-
+            <dependency>
+                <!-- TODO: Remove once this version is included in BOM -->
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>script-security</artifactId>
+                <version>1172.v35f6a_0b_8207e</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkinsci.plugins</groupId>
+                <artifactId>pipeline-model-api</artifactId>
+                <version>${pipeline-model-definition-plugin.version}</version>
+            </dependency>
+             <dependency>
+                <groupId>org.jenkinsci.plugins</groupId>
+                <artifactId>pipeline-model-extensions</artifactId>
+                <version>${pipeline-model-definition-plugin.version}</version>
+            </dependency>
+             <dependency>
+                <groupId>org.jenkinsci.plugins</groupId>
+                <artifactId>pipeline-stage-tags-metadata</artifactId>
+                <version>${pipeline-model-definition-plugin.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -68,6 +89,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
+            <version>${workflow-cps-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -100,6 +122,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
+            <version>${workflow-cps-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -116,12 +139,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>config-file-provider</artifactId>
-            <version>2.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
+            <version>${pipeline-model-definition-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -143,6 +166,7 @@
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
+            <version>${pipeline-model-definition-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerDSL.java
@@ -56,7 +56,7 @@ import org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist;
 
     @Extension
     public static class DockerDSLAllowlist extends GroovySourceFileAllowlist {
-        private final String scriptUrl = DockerDSL.class.getResource("/org/jenkinsci/plugins/docker/workflow/Docker.groovy").toString();
+        private final String scriptUrl = DockerDSL.class.getResource("Docker.groovy").toString();
 
         @Override
         public boolean isAllowed(String groovyResourceUrl) {

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/DockerDSL.java
@@ -28,6 +28,7 @@ import groovy.lang.Binding;
 import hudson.Extension;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
+import org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist;
 
 /**
  * Something you should <strong>not copy</strong>. Write plain old {@code Step}s and leave it at that.
@@ -53,4 +54,13 @@ import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
         return docker;
     }
 
+    @Extension
+    public static class DockerDSLAllowlist extends GroovySourceFileAllowlist {
+        private final String scriptUrl = DockerDSL.class.getResource("/org/jenkinsci/plugins/docker/workflow/Docker.groovy").toString();
+
+        @Override
+        public boolean isAllowed(String groovyResourceUrl) {
+            return groovyResourceUrl.equals(scriptUrl);
+        }
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent.java
@@ -28,8 +28,10 @@ import java.util.Map;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption;
+import org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist;
 import org.kohsuke.stapler.DataBoundSetter;
 
 public abstract class AbstractDockerAgent<D extends AbstractDockerAgent<D>> extends DeclarativeAgent<D> {
@@ -121,6 +123,20 @@ public abstract class AbstractDockerAgent<D extends AbstractDockerAgent<D>> exte
     @Override
     public boolean reuseRootAgent(Map<String, DeclarativeOption> options) {
         return options.get(ContainerPerStage.SYMBOL) != null;
+    }
+
+    /**
+     * AbstractDockerPipelineScript.groovy is a superclass of the Groovy scripts for subclasses of
+     * {@link AbstractDockerAgent}, but does not have any direct equivalent Java class, so we just allow it here.
+     */
+    @Extension
+    public static class ChangelogConditionalScriptAllowlist extends GroovySourceFileAllowlist {
+        private final String scriptUrl = AbstractDockerAgent.class.getResource("/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerPipelineScript.groovy").toString();
+
+        @Override
+        public boolean isAllowed(String groovyResourceUrl) {
+            return groovyResourceUrl.equals(scriptUrl);
+        }
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerAgent.java
@@ -131,7 +131,7 @@ public abstract class AbstractDockerAgent<D extends AbstractDockerAgent<D>> exte
      */
     @Extension
     public static class ChangelogConditionalScriptAllowlist extends GroovySourceFileAllowlist {
-        private final String scriptUrl = AbstractDockerAgent.class.getResource("/org/jenkinsci/plugins/docker/workflow/declarative/AbstractDockerPipelineScript.groovy").toString();
+        private final String scriptUrl = AbstractDockerAgent.class.getResource("AbstractDockerPipelineScript.groovy").toString();
 
         @Override
         public boolean isAllowed(String groovyResourceUrl) {

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/FromFingerprintStepTest.java
@@ -54,9 +54,11 @@ public class FromFingerprintStepTest {
         String script = "node {\n" +
             "  sh 'mkdir buildWithFROMArgs'\n" +
             "  writeFile file: 'Dockerfile', text: '" + dockerFile + "'\n" +
+            "  withEnv(['DOCKER_BUILDKIT=0']) {\n" +
             "  def built = docker.build('my-tag') \n" +
             "  dockerFingerprintFrom dockerfile: 'Dockerfile', image: 'my-tag' \n" +
             "  echo \"built ${built.id}\"\n" +
+            "  }\n" +
             "}";
 
         assertBuild("build", script, BUSYBOX_IMAGE);

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/dockerPullLocalImage.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/dockerPullLocalImage.groovy
@@ -27,13 +27,13 @@ pipeline {
     stages {
         stage("build image") {
             steps {
-                sh 'docker build -t maven:3-alpine .'
+                sh 'docker build -t maven:3-jdk-8-slim .'
             }
         }
         stage("in built image") {
             agent {
                 docker {
-                    image "maven:3-alpine"
+                    image "maven:3-jdk-8-slim"
                     args "-v /tmp:/tmp"
                     reuseNode true
                 }
@@ -46,7 +46,7 @@ pipeline {
         stage("in pulled image") {
             agent {
                 docker {
-                    image "maven:3-alpine"
+                    image "maven:3-jdk-8-slim"
                     alwaysPull true
                 }
             }


### PR DESCRIPTION
See https://github.com/jenkinsci/workflow-cps-plugin/pull/538 and https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/529. This would not be needed except for the fact that `DockerPipelineFromDockerfileScript.groovy` and `DockerPipelineScript.groovy` inherit from `AbstractDockerPipelineScript.groovy`, which does not correspond to any concrete subclass of `WithScriptDescribable`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
