### PR TITLE
Fix WithContainerStepTest.stop and WithContainerStepTest.death

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -185,8 +185,8 @@ public class WithContainerStepTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +
-                    "  withDockerContainer('httpd:2.4.12') {\n" +
-                    "    sh \"sleep 5; ps -e -o pid,command | egrep '${pwd tmp: true}/durable-.+/script.sh' | fgrep -v grep | sort -n | tr -s ' ' | cut -d ' ' -f2 | xargs kill -9\"\n" +
+                    "  withDockerContainer('httpd:2.4.54-alpine') {\n" +
+                    "    sh \"set -e; sleep 5; ps -e -o pid,args | egrep '${pwd tmp: true}/durable-.+/script.sh' | fgrep -v grep | sort -n | tr -s ' ' | cut -d ' ' -f2 | xargs kill -9\"\n" +
                     "  }\n" +
                     "}", true));
                 Field hci = BourneShellScript.class.getDeclaredField("HEARTBEAT_CHECK_INTERVAL");

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -164,7 +164,7 @@ public class WithContainerStepTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +
-                    "  withDockerContainer('httpd:2.4.12') {\n" +
+                    "  withDockerContainer('ubuntu:kinetic-20220602') {\n" +
                     "    sh 'trap \\'echo got SIGTERM\\' TERM; trap \\'echo exiting; exit 99\\' EXIT; echo sleeping now with JENKINS_SERVER_COOKIE=$JENKINS_SERVER_COOKIE; sleep 999'\n" +
                     "  }\n" +
                     "}", true));


### PR DESCRIPTION
I saw these flake in #256 and didn't think much of it, but then I saw them also fail in https://github.com/jenkinsci/docker-workflow-plugin/pull/253, and took a look. There seem to be a lot of problems with our use of `ps`.

The real head scratcher for me though is that the tests pass locally with `httpd:2.4.12`. They only fail if I use `httpd:2.4.35` or newer (which I believe is due to the switch to a `-slim` version of Debian in https://github.com/docker-library/httpd/pull/113 which _removes_ `ps` from the container entirely, but it is hard to track things down because that repo does not have tags/releases). If I do update to 2.4.35 or newer then I get the exact error messages seen in CI. Is something in the CI environment forcing newer images to be used? Is that even possible?

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
