### PR TITLE
Do not pass a null `Launcher` to `DockerClient`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -107,7 +107,7 @@ public class WithContainerStep extends AbstractStepImpl {
         this.toolName = Util.fixEmpty(toolName);
     }
 
-    private static void destroy(String container, Launcher launcher, Node node, EnvVars launcherEnv, String toolName) throws Exception {
+    private static void destroy(String container, @NonNull Launcher launcher, Node node, EnvVars launcherEnv, String toolName) throws Exception {
         new DockerClient(launcher, node, toolName).stop(launcherEnv, container);
     }
 
@@ -410,7 +410,10 @@ public class WithContainerStep extends AbstractStepImpl {
         }
 
         @Override protected void finished(StepContext context) throws Exception {
-            destroy(container, context.get(Launcher.class), context.get(Node.class), context.get(EnvVars.class), toolName);
+            Launcher launcher = context.get(Launcher.class);
+            if (launcher != null) {
+                destroy(container, launcher, context.get(Node.class), context.get(EnvVars.class), toolName);
+            }
         }
 
     }


### PR DESCRIPTION
https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/PR-793/2/console (https://github.com/jenkinsci/acceptance-test-harness/pull/793) failed due to an infrastructure problem:

```
java.io.IOException: Unable to create live FilePath for EC2 (aws-us-east-2) - High memory ubuntu 20.04 (i-0ff0c81a874559911)
	at org.jenkinsci.plugins.workflow.support.steps.FilePathDynamicContext.get(FilePathDynamicContext.java:66)
	at org.jenkinsci.plugins.workflow.support.steps.FilePathDynamicContext.get(FilePathDynamicContext.java:48)
	at org.jenkinsci.plugins.workflow.steps.DynamicContext$Typed.get(DynamicContext.java:95)
	at org.jenkinsci.plugins.workflow.cps.ContextVariableSet.get(ContextVariableSet.java:139)
	at org.jenkinsci.plugins.workflow.cps.CpsThread.getContextVariable(CpsThread.java:137)
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext.doGet(CpsStepContext.java:298)
	at org.jenkinsci.plugins.workflow.cps.CpsBodySubContext.doGet(CpsBodySubContext.java:88)
	at org.jenkinsci.plugins.workflow.support.DefaultStepContext.get(DefaultStepContext.java:75)
	at org.jenkinsci.plugins.junitrealtimetestreporter.RealtimeJUnitStep.finished(RealtimeJUnitStep.java:299)
	at org.jenkinsci.plugins.junitrealtimetestreporter.RealtimeJUnitStep.access$200(RealtimeJUnitStep.java:71)
	at org.jenkinsci.plugins.junitrealtimetestreporter.RealtimeJUnitStep$Execution2$Callback2.lambda$onFailure$1(RealtimeJUnitStep.java:225)
	at org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution.lambda$run$0(GeneralNonBlockingStepExecution.java:77)
	at …
```

This seems to have produced a secondary error in this plugin trying to clean up on a node which no longer exists, merely adding to the noise:

```
 java.lang.NullPointerException
 	at org.jenkinsci.plugins.docker.workflow.client.DockerClient.launch(DockerClient.java:296)
 	at org.jenkinsci.plugins.docker.workflow.client.DockerClient.launch(DockerClient.java:292)
 	at org.jenkinsci.plugins.docker.workflow.client.DockerClient.launch(DockerClient.java:289)
 	at org.jenkinsci.plugins.docker.workflow.client.DockerClient.stop(DockerClient.java:182)
 	at org.jenkinsci.plugins.docker.workflow.WithContainerStep.destroy(WithContainerStep.java:110)
 	at org.jenkinsci.plugins.docker.workflow.WithContainerStep.access$400(WithContainerStep.java:77)
 	at org.jenkinsci.plugins.docker.workflow.WithContainerStep$Callback.finished(WithContainerStep.java:402)
 	at org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback$TailCall.onFailure(BodyExecutionCallback.java:128)
 	at org.jenkinsci.plugins.workflow.cps.CpsBodyExecution$FailureAdapter.receive(CpsBodyExecution.java:360)
 	at com.cloudbees.groovy.cps.impl.ThrowBlock$1.receive(ThrowBlock.java:68)
 	at …
```
