### PR TITLE
Add support for Jenkins in Docker with non-backward-compatible cgroup v2, such as in Docker Desktop on Mac.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,6 @@ Summary
 
 A full description is available in the plugin’s [documentation](https://go.cloudbees.com/docs/plugins/docker-workflow/).
 
-Building
----
-```console
-rm -rf target               # if you want a 100% clean build
-mvn package -DskipTests
-```
-
-This will create a target/docker-workflow.hpi file, which can be uploaded manually to Jenkins by clicking Dashboard -> Manage Jenkins -> Manage Plugins -> Advanced, then scrolling down to the section titled Deploy Plugin, clicking Deploy Plugin, selecting this file, and clicking Deploy.
-
-After deploying, you will need to restart Jenkins.  When Jenkins is running in Docker, it apparently is not capable of restarting itself, so you'll have to stop the Docker container and restart it.
-
 Demo
 ---
 The plugin has an outdated Docker-based demo. See the [demo README from v1.12](https://github.com/jenkinsci/docker-workflow-plugin/tree/docker-workflow-1.12/demo) for setup and launch guidelines.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ Summary
 
 A full description is available in the plugin’s [documentation](https://go.cloudbees.com/docs/plugins/docker-workflow/).
 
+Building
+---
+```console
+rm -rf target               # if you want a 100% clean build
+mvn package -DskipTests
+```
+
+This will create a target/docker-workflow.hpi file, which can be uploaded manually to Jenkins by clicking Dashboard -> Manage Jenkins -> Manage Plugins -> Advanced, then scrolling down to the section titled Deploy Plugin, clicking Deploy Plugin, selecting this file, and clicking Deploy.
+
+After deploying, you will need to restart Jenkins.  When Jenkins is running in Docker, it apparently is not capable of restarting itself, so you'll have to stop the Docker container and restart it.
+
 Demo
 ---
 The plugin has an outdated Docker-based demo. See the [demo README from v1.12](https://github.com/jenkinsci/docker-workflow-plugin/tree/docker-workflow-1.12/demo) for setup and launch guidelines.

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -166,7 +166,7 @@ public class WithContainerStep extends AbstractStepImpl {
 
             Map<String, String> volumes = new LinkedHashMap<String, String>();
             Collection<String> volumesFromContainers = new LinkedHashSet<String>();
-            Optional<String> containerId = dockerClient.getContainerIdIfContainerized();
+            Optional<String> containerId = dockerClient.getContainerIdIfContainerized(env);
             if (containerId.isPresent()) {
                 listener.getLogger().println(node.getDisplayName() + " seems to be running inside container " + containerId.get());
                 final Collection<String> mountedVolumes = dockerClient.getVolumes(env, containerId.get());

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -361,7 +361,7 @@ public class DockerClient {
                     return containerId;
                 }
             } catch (IOException ex) {
-                System.err.println("Caught non-critical exception attempting to read deprecated/obsolete cgroup 1.x: " + ex.getMessage());
+                LOGGER.log(Level.FINE, "Unable to detect container ID using cgroup v1 API, will try using cgroup v2 API", ex);
             }
         }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -371,17 +371,21 @@ public class DockerClient {
             FilePath hostnameFile = node.createPath("/etc/hostname");
             if (hostnameFile != null && hostnameFile.exists()) {
                 BufferedReader r = new BufferedReader(new InputStreamReader(hostnameFile.read(), StandardCharsets.UTF_8));
-                String line;
-                if ((line = r.readLine()) != null) {
-                    line = line.trim();
-                    Matcher matcher = Pattern.compile("^([a-z0-9]{12})$").matcher(line);
-                    if (matcher.find()) {
-                        String containerId = matcher.group();
-                        List<String> processes = listProcess(launchEnv, containerId);
-                        if (!processes.isEmpty()) {
-                            return Optional.of(containerId);
+                try {
+                    String line;
+                    if ((line = r.readLine()) != null) {
+                        line = line.trim();
+                        Matcher matcher = Pattern.compile("^([a-z0-9]{12})$").matcher(line);
+                        if (matcher.find()) {
+                            String containerId = matcher.group();
+                            List<String> processes = listProcess(launchEnv, containerId);
+                            if (!processes.isEmpty()) {
+                                return Optional.of(containerId);
+                            }
                         }
                     }
+                } finally {
+                    r.close();
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -370,12 +370,12 @@ public class DockerClient {
         if (dockerenvFile != null && dockerenvFile.exists()) {
             FilePath hostnameFile = node.createPath("/etc/hostname");
             if (hostnameFile != null && hostnameFile.exists()) {
-                BufferedReader r = new BufferedReader(new InputStreamReader(hostnameFile.read(), StandardCharsets.UTF_8));
-                try {
+                Pattern containerIdPattern = Pattern.compile("^([a-z0-9]{12})$");
+                try (BufferedReader r = new BufferedReader(new InputStreamReader(hostnameFile.read(), StandardCharsets.UTF_8))) {
                     String line;
                     if ((line = r.readLine()) != null) {
                         line = line.trim();
-                        Matcher matcher = Pattern.compile("^([a-z0-9]{12})$").matcher(line);
+                        Matcher matcher = containerIdPattern.matcher(line);
                         if (matcher.find()) {
                             String containerId = matcher.group();
                             List<String> processes = listProcess(launchEnv, containerId);
@@ -384,8 +384,6 @@ public class DockerClient {
                             }
                         }
                     }
-                } finally {
-                    r.close();
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
@@ -83,7 +83,7 @@ public class WindowsDockerClient extends DockerClient {
     }
 
     @Override
-    public Optional<String> getContainerIdIfContainerized() throws IOException, InterruptedException {
+    public Optional<String> getContainerIdIfContainerized(@NonNull EnvVars launchEnv) throws IOException, InterruptedException {
         if (node == null ||
             launch(new EnvVars(), true, null, "sc.exe", "query", "cexecsvc").getStatus() != 0) {
             return Optional.absent();


### PR DESCRIPTION
This plugin is written specifically around cgroup v1 which is deprecated / obsolete.  The result is that with cgroup v2, it fails to detect that Jenkins is running inside a container, so the /var/jenkins_home directory doesn't get mounted correctly inside the target docker container during the build step, and the commands running inside the target docker container fail and the build hangs and eventually times out.

The fix is to look for a /.dockerenv file, and if it exists, attempt to read Jenkins' container Id from /etc/hosts, matching it with a regex, and then if it matches the pattern of a Docker container Id, using the listProcess() function to list the processes running inside Jenkins' docker container, and if empty, assume that we have a valid container Id, and use it.

This fix works properly with Docker Desktop on Mac, and should work pretty much everywhere else Jenkins is run inside a Docker container.

It still tries cgroup v1 first, and only falls back to /.dockerenv and /etc/hosts if cgroup v1 fails to determine Jenkins' container Id.

Please merge and issue a new release ASAP, as I have a project which is dependent upon this plugin, and I need it working correctly when Jenkins is running under Docker.

Thanks!
Ron Cemer