### PR TITLE
Use HTTPS SCM URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <scm>
-      <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+      <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
       <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
       <url>https://github.com/${gitHubRepo}</url>
       <tag>${scmTag}</tag>


### PR DESCRIPTION
The old protocol is [deprecated](https://github.blog/2021-09-01-improving-git-protocol-security-github/).