### PR TITLE
[JENKINS-70132] Remove anonymous volumes when removing the container

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -199,7 +199,7 @@ public class DockerClient {
      */
     public void rm(@NonNull EnvVars launchEnv, @NonNull String containerId) throws IOException, InterruptedException {
         LaunchResult result;
-        result = launch(launchEnv, false, "rm", "-f", containerId);
+        result = launch(launchEnv, false, "rm", "-f", "--volumes", containerId);
         if (result.getStatus() != 0) {
             throw new IOException(String.format("Failed to rm container '%s'.", containerId));
         }

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/Docker.groovy
@@ -211,7 +211,7 @@ class Docker implements Serializable {
 
         public void stop() {
             docker.script.withEnv(["JD_ID=${id}"]) {
-                docker.script."${docker.shell(isUnix)}" 'docker stop "' + docker.asEnv(isUnix,'JD_ID') + '" && docker rm -f "' + docker.asEnv(isUnix, 'JD_ID') + '"'
+                docker.script."${docker.shell(isUnix)}" 'docker stop "' + docker.asEnv(isUnix,'JD_ID') + '" && docker rm -f --volumes "' + docker.asEnv(isUnix, 'JD_ID') + '"'
             }
         }
 

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientTest.java
@@ -57,19 +57,22 @@ public class DockerClientTest {
 
     @Test
     public void test_run() throws IOException, InterruptedException {
+        // Pin to a specific sha256 hash of the image to avoid any potential issues with the image changing in the future.
+        // Original image tag: docker:20.10.9-dind
+        String image = "docker.io/library/docker@sha256:d842418d21545fde57c2512681d9bdc4ce0e54f2e0305a293ee20a9b6166932b";
         EnvVars launchEnv = DockerTestUtil.newDockerLaunchEnv();
         String containerId =
-                dockerClient.run(launchEnv, "docker:20.10.9-dind", null, null, Collections.<String, String>emptyMap(), Collections.<String>emptyList(), new EnvVars(),
+                dockerClient.run(launchEnv, image, null, null, Collections.<String, String>emptyMap(), Collections.<String>emptyList(), new EnvVars(),
                         dockerClient.whoAmI(), "cat");
         Assert.assertEquals(64, containerId.length());
         ContainerRecord containerRecord = dockerClient.getContainerRecord(launchEnv, containerId);
-        Assert.assertEquals(dockerClient.inspect(launchEnv, "docker:20.10.9-dind", ".Id"), containerRecord.getImageId());
+        Assert.assertEquals(dockerClient.inspect(launchEnv, image, ".Id"), containerRecord.getImageId());
         Assert.assertTrue(containerRecord.getContainerName().length() > 0);
         Assert.assertTrue(containerRecord.getHost().length() > 0);
         Assert.assertTrue(containerRecord.getCreated() > 1000000000000L);
-        Assert.assertEquals(Collections.<String>emptyList(), dockerClient.getVolumes(launchEnv, containerId));
 
-        // Check that an anonymous volume was created
+        // Check that an anonymous volume was created mounted at /var/lib/docker
+        Assert.assertEquals(Collections.<String>singletonList("/var/lib/docker"), dockerClient.getVolumes(launchEnv, containerId));
         String anonymousVolumeName = dockerClient.inspect(launchEnv, containerId, "range .Mounts }}{{ .Name }}{{ end");
         Assert.assertEquals(64, anonymousVolumeName.length());
 


### PR DESCRIPTION
For example, the following Jenkinsfile:

```groovy
pipeline {
  agent {
    docker {
      image 'docker:dind'
    }
  }
}
```

Will create the container based on `docker:dind`, which declares a `VOLUME` that docker creates automatically (this is called anonymous volumes).

However, due to the way how Jenkins deletes the container after finishing the build, it will leave the anonymous volume dangling on the agent.

Over time, this can cause issues as these volumes can consume a high amount of disk space and there's no current Jenkins mechanism to delete them other than "manually".

This now aligns with the behavior of `docker run --rm`, which not only deletes the container itself but also its anonymous volumes.

Fixes [JENKINS-70132](https://issues.jenkins.io/browse/JENKINS-70132)