### PR TITLE
Jenkins 60473 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,9 +163,8 @@
                 <configuration>
                     <systemProperties combine.children="append">
                         <property>
-                            <!-- TODO copied from pipeline-model-definition; better to docker pull images before invoking timeout -->
-                            <name>jenkins.test.timeout</name>
-                            <value>600</value>
+                            <name>org.slf4j.simpleLogger.defaultLogLevel</name>
+                            <value>info</value>
                         </property>
                     </systemProperties>
                 </configuration>

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -161,7 +161,9 @@ public class WithContainerStep extends AbstractStepImpl {
             }
 
             FilePath tempDir = tempDir(workspace);
+
             tempDir.mkdirs();
+
             String tmp = getPath(tempDir);
 
             Map<String, String> volumes = new LinkedHashMap<String, String>();
@@ -196,7 +198,8 @@ public class WithContainerStep extends AbstractStepImpl {
                 volumes.put(tmp, tmp);
             }
 
-            String command = launcher.isUnix() ? "cat" : "cmd.exe";
+            String command = "cat";
+            //String command = launcher.isUnix() ? "cat" : "cmd.exe";
             container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ command);
             final List<String> ps = dockerClient.listProcess(env, container);
             if (!ps.contains(command)) {

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -199,6 +199,7 @@ public class WithContainerStep extends AbstractStepImpl {
             }
 
             String command = "cat";
+            //this command will run on the container, not the agent. 'cat' is the correct command
             //String command = launcher.isUnix() ? "cat" : "cmd.exe";
             container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ command);
             final List<String> ps = dockerClient.listProcess(env, container);

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -185,21 +185,21 @@ public class DockerClient {
             stop(launchEnv, containerId, 1);
         }
         public void stop(@NonNull EnvVars launchEnv, @NonNull String containerId, @NonNull int stopTime) throws IOException, InterruptedException {
-        LaunchResult result = launch(launchEnv, false, "docker", "stop", String.format("--time=%s", stopTime), containerId);
-        // ~ This approach for checking container shutdown status does not wait for the container to shut down. We should be using the inspect method
-        // instead ~
-        //if (result.getStatus() != 0) {
-        //    throw new IOException(String.format("Failed to kill container '%s'.  ==== %s", containerId, result.getStatus()));
-        //}
-        Thread.sleep((long)stopTime*1100);
-        if(inspect(launchEnv, containerId, ".Name")==null){
-            throw new IOException(String.format("Container '%s' failed to kill.", containerId));
-        }
+            LaunchResult result = launch(launchEnv, false, "docker", "stop", String.format("--time=%s", stopTime), containerId);
+            // ~ This approach for checking container shutdown status does not wait for the container to shut down. We should be using the inspect method
+            // instead ~
+            //if (result.getStatus() != 0) {
+            //    throw new IOException(String.format("Failed to kill container '%s'.  ==== %s", containerId, result.getStatus()));
+            //}
+            Thread.sleep((long)stopTime*1100);
+            if(inspect(launchEnv, containerId, ".Name")==null){
+                throw new IOException(String.format("Container '%s' failed to kill.", containerId));
+            }
 
-        if (!SKIP_RM_ON_STOP) {
-            rm(launchEnv, containerId);
+            if (!SKIP_RM_ON_STOP) {
+                rm(launchEnv, containerId);
+            }
         }
-    }
 
     /**
      * Remove a container.

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -189,6 +189,7 @@ public class DockerClient {
         if (!SKIP_RM_ON_STOP) {
             rm(launchEnv, containerId);
         }
+        throw new IOException(String.format("Failed to kill container '%s'.", containerId));
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -181,15 +181,24 @@ public class DockerClient {
      * @param launchEnv Docker client launch environment.
      * @param containerId The container ID.
      */
-    public void stop(@NonNull EnvVars launchEnv, @NonNull String containerId) throws IOException, InterruptedException {
-        LaunchResult result = launch(launchEnv, false, "stop", "--time=1", containerId);
-        if (result.getStatus() != 0) {
-            throw new IOException(String.format("Failed to kill container '%s'.", containerId));
+        public void stop(@NonNull EnvVars launchEnv, @NonNull String containerId) throws IOException, InterruptedException {
+            stop(launchEnv, containerId, 1);
         }
+        public void stop(@NonNull EnvVars launchEnv, @NonNull String containerId, @NonNull int stopTime) throws IOException, InterruptedException {
+        LaunchResult result = launch(launchEnv, false, "docker", "stop", String.format("--time=%s", stopTime), containerId);
+        // ~ This approach for checking container shutdown status does not wait for the container to shut down. We should be using the inspect method
+        // instead ~
+        //if (result.getStatus() != 0) {
+        //    throw new IOException(String.format("Failed to kill container '%s'.  ==== %s", containerId, result.getStatus()));
+        //}
+        Thread.sleep((long)stopTime*1100);
+        if(inspect(launchEnv, containerId, ".Name")==null){
+            throw new IOException(String.format("Container '%s' failed to kill.", containerId));
+        }
+
         if (!SKIP_RM_ON_STOP) {
             rm(launchEnv, containerId);
         }
-        throw new IOException(String.format("Failed to kill container '%s'.", containerId));
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
@@ -29,6 +29,14 @@ public class WindowsDockerClient extends DockerClient {
         this.node = node;
     }
 
+    private String getDockerFormattedPath(@NonNull String path){
+        path=path.replace(":", "/");
+        if(path.charAt(0)!='/'){
+            path="/"+path.substring(1);
+        }
+        return path;
+    }
+
     @Override
     public String run(@NonNull EnvVars launchEnv, @NonNull String image, @CheckForNull String args, @CheckForNull String workdir, @NonNull Map<String, String> volumes, @NonNull Collection<String> volumesFromContainers, @NonNull EnvVars containerEnv, @NonNull String user, @NonNull String... command) throws IOException, InterruptedException {
         ArgumentListBuilder argb = new ArgumentListBuilder("docker", "run", "-d", "-t");
@@ -37,10 +45,10 @@ public class WindowsDockerClient extends DockerClient {
         }
 
         if (workdir != null) {
-            argb.add("-w", workdir);
+            argb.add("-w", getDockerFormattedPath(workdir));
         }
         for (Map.Entry<String, String> volume : volumes.entrySet()) {
-            argb.add("-v", volume.getKey() + ":" + volume.getValue());
+            argb.add("-v", getDockerFormattedPath(volume.getKey()) + ":" + getDockerFormattedPath(volume.getValue()));
         }
         for (String containerId : volumesFromContainers) {
             argb.add("--volumes-from", containerId);

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
@@ -30,7 +30,7 @@ public class WindowsDockerClient extends DockerClient {
     }
 
     private String getDockerFormattedPath(@NonNull String path){
-        path=path.replaceAll(":", "").replaceAll("\"", "");
+        path=path.replaceAll(":", "").replaceAll("\"", "").replaceAll("\"", "");
         if(!path.startsWith("/")){
             path="/"+path;
         }
@@ -121,7 +121,11 @@ public class WindowsDockerClient extends DockerClient {
     }
 
     private LaunchResult launch(EnvVars env, boolean quiet, FilePath workDir, String... args) throws IOException, InterruptedException {
-        return launch(env, quiet, workDir, new ArgumentListBuilder(args));
+        String[] newArgs = new String[args.length];
+        for (int i = 0; i < args.length; i++) {
+            newArgs[i]=getDockerFormattedPath(args[i]);
+        }
+        return launch(env, quiet, workDir, new ArgumentListBuilder(newArgs));
     }
     private LaunchResult launch(EnvVars env, boolean quiet, FilePath workDir, ArgumentListBuilder argb) throws IOException, InterruptedException {
         if (LOGGER.isLoggable(Level.FINE)) {

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
@@ -30,8 +30,8 @@ public class WindowsDockerClient extends DockerClient {
     }
 
     private String getDockerFormattedPath(@NonNull String path){
-        path=path.replaceAll(":", "").replaceAll("\"", "").replaceAll("\"", "");
-        if(!path.startsWith("/")){
+        path=path.replaceAll(":", "");
+        if(!path.startsWith("/")&&path.contains("/")){
             path="/"+path;
         }
         return path;
@@ -75,7 +75,7 @@ public class WindowsDockerClient extends DockerClient {
         }
         List<String> processes = new ArrayList<>();
         try (Reader r = new StringReader(result.getOut());
-             BufferedReader in = new BufferedReader(r)) {
+            BufferedReader in = new BufferedReader(r)) {
             String line;
             in.readLine(); // ps header
             while ((line = in.readLine()) != null) {

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
@@ -30,7 +30,10 @@ public class WindowsDockerClient extends DockerClient {
     }
 
     private String getDockerFormattedPath(@NonNull String path){
-        path=path.replace(":", "/");
+        path=path.replaceAll(":", "").replaceAll("\"", "");
+        if(!path.startsWith("/")){
+            path="/"+path;
+        }
         return path;
     }
 
@@ -60,7 +63,7 @@ public class WindowsDockerClient extends DockerClient {
         if (result.getStatus() == 0) {
             return result.getOut();
         } else {
-            throw new IOException(String.format("Failed to run image '%s'. Error: %s", image, result.getErr()));
+            throw new IOException(String.format("(WindowsClient) Failed to run image '%s'. Error: %s", image, result.getErr()));
         }
     }
 
@@ -68,7 +71,7 @@ public class WindowsDockerClient extends DockerClient {
     public List<String> listProcess(@NonNull EnvVars launchEnv, @NonNull String containerId) throws IOException, InterruptedException {
         LaunchResult result = launch(launchEnv, false, null, "docker", "top", containerId);
         if (result.getStatus() != 0) {
-            throw new IOException(String.format("Failed to run top '%s'. Error: %s", containerId, result.getErr()));
+            throw new IOException(String.format("(WindowsClient) Failed to run top '%s'. Error: %s", containerId, result.getErr()));
         }
         List<String> processes = new ArrayList<>();
         try (Reader r = new StringReader(result.getOut());

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClient.java
@@ -31,9 +31,6 @@ public class WindowsDockerClient extends DockerClient {
 
     private String getDockerFormattedPath(@NonNull String path){
         path=path.replace(":", "/");
-        if(path.charAt(0)!='/'){
-            path="/"+path.substring(1);
-        }
         return path;
     }
 

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -144,7 +144,7 @@ public class DockerDSLTest {
                         "  sh 'mvn -version'\n" +
                         "}", true));
 
-                story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                story.j.assertBuildStatusSuccess(p.scheduleBuild2(10));
             }
         });
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-60473
(Windows 10, JDK11) In windowsDockerClient.run(), the workspace path was using the colon (:) character, which is reserved by the Docker cli. Docker expects this to be a forward-slash (/) instead. Because it is specific to the windows client, I added a function to the windows client class, which replaces the character. This ensures the path is Docker-ready.
Root-level configurations (outside windowsDockerClient) have not been changed, to avoid interfering docker commands on other OS. 


### Testing done:
Automated tests.
Imported to Jenkins, to ensure the pipeline successfully runs the docker commands in windowsDockerClient.run(). The error previously experienced has been cleared.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
