### PR TITLE
Fixed Absolute path, and container not stopping issues

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -196,7 +196,7 @@ public class WithContainerStep extends AbstractStepImpl {
                 volumes.put(tmp, tmp);
             }
 
-            String command = launcher.isUnix() ? "cat" : "cmd.exe";
+            String command = "cat";
             container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ command);
             final List<String> ps = dockerClient.listProcess(env, container);
             if (!ps.contains(command)) {

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -182,10 +182,15 @@ public class DockerClient {
      * @param containerId The container ID.
      */
     public void stop(@NonNull EnvVars launchEnv, @NonNull String containerId) throws IOException, InterruptedException {
-        LaunchResult result = launch(launchEnv, false, "stop", "--time=1", containerId);
-        if (result.getStatus() != 0) {
-            throw new IOException(String.format("Failed to kill container '%s'.", containerId));
+        stop(launchEnv, containerId, 1);
+    }
+    public void stop(@NonNull EnvVars launchEnv, @NonNull String containerId, @NonNull int stopTime) throws IOException, InterruptedException {
+        LaunchResult result = launch(launchEnv, false, "docker", "stop", String.format("--time=%s", stopTime), containerId);
+        Thread.sleep((long)stopTime*1100);
+        if(inspect(launchEnv, containerId, ".Name")==null){
+            throw new IOException(String.format("Container '%s' failed to kill.", containerId));
         }
+
         if (!SKIP_RM_ON_STOP) {
             rm(launchEnv, containerId);
         }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-60473
This pull request fixes a few of the issues faced by windows users, when using this plugin. Full details can be found below test results

[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.jenkinsci.plugins.docker.workflow.client.WindowsDockerClientTest
$ docker run -d -t learn/tutorial cat
$ docker docker stop --time=1 4d240d1fee262a891f2787702df34a16c5579ec9a9d241db2755305fca3f3f10
$ docker rm -f --volumes 4d240d1fee262a891f2787702df34a16c5579ec9a9d241db2755305fca3f3f10
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.813 s -- in org.jenkinsci.plugins.docker.workflow.client.WindowsDockerClientTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  16.791 s
[INFO] Finished at: 2023-09-17T12:56:17+10:00
[INFO] ------------------------------------------------------------------------

<!-- Comment:
This modification fixed the 'absolute path error', by enforcing docker-formatted paths, when using a windows agent. This has been done in WindowsDockerClient.java, so as to not interfere with upstream paths. 
Once this was fixed, the error was cleared, but there was still an issue with containers failing to stop, which was causing tests to fail. It was found that this is due to how the containers state was being checked after closing it. The code was synchronously checking for container shutdown status, but docker was waiting for timeout (time=1) before it would return a containerID. To fix this, I made the stop() function of DockerClient close a container, wait for slightly longer than the time it takes to shut the container down, then check the status using the 'inspect function'. This fix was performed directly in DockerClient, because this  relates to how the code interacts with docker (and is agnostic of the agent's host OS) - so this should be an appropriate way to do this on both Linux and Windows.
Finally, the WithContainerStep script has some issues with Linux containers running on windows agents. This is because some units of logic were checking the OS of the agent, to apply appropriate commands to the container. In doing so, our code was trying to make commands like  'cmd.exe' on Linux containers.  
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
