### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: false, configurations: [
   [platform: 'linux', jdk: 21],
-  [platform: 'maven-11-windows', jdk: 17] // TODO Docker-based tests fail when using Docker on Windows. The maven-windows agents do not have Docker installed so tests that require Docker are skipped.
+  [platform: 'maven-17-windows', jdk: 17] // TODO Docker-based tests fail when using Docker on Windows. The maven-windows agents do not have Docker installed so tests that require Docker are skipped.
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: false, configurations: [
-  [platform: 'linux', jdk: 17],
-  [platform: 'maven-11-windows', jdk: 11] // TODO Docker-based tests fail when using Docker on Windows. The maven-windows agents do not have Docker installed so tests that require Docker are skipped.
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: false, configurations: [
   [platform: 'linux', jdk: 21],
-  [platform: 'windows', jdk: 17],
+  [platform: 'maven-11-windows', jdk: 17] // TODO Docker-based tests fail when using Docker on Windows. The maven-windows agents do not have Docker installed so tests that require Docker are skipped.
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.72</version>
+        <version>4.73</version>
         <relativePath />
     </parent>
     <artifactId>docker-workflow</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.73</version>
+        <version>4.74</version>
         <relativePath />
     </parent>
     <artifactId>docker-workflow</artifactId>


### PR DESCRIPTION
## Test with Java 21

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is low. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Updates the parent pom to the most recent release.

Supersedes pull request:

* #302

### Testing done

Confirmed that tests pass with Java 21

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
