### PR TITLE
Enable Additional Docker Run Arguments

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -55,6 +55,7 @@ import java.util.TreeSet;
 import org.jenkinsci.plugins.docker.commons.tools.DockerTool;
 import org.jenkinsci.plugins.docker.workflow.client.DockerClient;
 import org.jenkinsci.plugins.docker.workflow.client.WindowsDockerClient;
+import org.jenkinsci.plugins.docker.workflow.declarative.DeclarativeDockerUtils;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
@@ -197,7 +198,8 @@ public class WithContainerStep extends AbstractStepImpl {
             }
 
             String command = launcher.isUnix() ? "cat" : "cmd.exe";
-            container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ command);
+            String args = (DeclarativeDockerUtils.getAdditionalRunArgs() + " " + Util.fixNull(step.args)).trim();
+            container = dockerClient.run(env, step.image, args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ command);
             final List<String> ps = dockerClient.listProcess(env, container);
             if (!ps.contains(command)) {
                 listener.error(

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtils.java
@@ -86,6 +86,27 @@ public class DeclarativeDockerUtils {
     }
 
     @Whitelisted
+    public static String getAdditionalRunArgs() {
+        return getAdditionalRunArgs(null);
+    }
+
+    @Whitelisted
+    public static String getAdditionalRunArgs(@Nullable String override) {
+        if (!StringUtils.isBlank(override)) {
+            return override;
+        } else {
+            Run<?,?> r = currentRun();
+            for (DockerPropertiesProvider provider : DockerPropertiesProvider.all()) {
+                String additionalRunArgs = provider.getAdditionalRunArgs(r);
+                if (!StringUtils.isBlank(additionalRunArgs)) {
+                    return additionalRunArgs;
+                }
+            }
+        }
+        return "";
+    }
+
+    @Whitelisted
     public static WithScriptScript<?> getLabelScript(AbstractDockerAgent<?> describable, CpsScript script) throws Exception {
         String targetLabel = getLabel(describable.getLabel());
         Label l = (Label) Label.DescriptorImpl.instanceForName("label", Collections.singletonMap("label", targetLabel));

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerPropertiesProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/DockerPropertiesProvider.java
@@ -44,6 +44,9 @@ public abstract class DockerPropertiesProvider implements ExtensionPoint {
     @CheckForNull
     public abstract String getLabel(@Nullable Run run);
 
+    @CheckForNull
+    public abstract String getAdditionalRunArgs(@Nullable Run run);
+
     public static ExtensionList<DockerPropertiesProvider> all() {
         return ExtensionList.lookup(DockerPropertiesProvider.class);
     }

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig.java
@@ -57,6 +57,7 @@ public class GlobalConfig extends GlobalConfiguration {
     private static final Logger LOGGER = Logger.getLogger(GlobalConfig.class.getName());
 
     private String dockerLabel;
+    private String additionalRunArgs;
     private DockerRegistryEndpoint registry;
 
     public GlobalConfig() {
@@ -79,9 +80,18 @@ public class GlobalConfig extends GlobalConfiguration {
         return Util.fixEmpty(dockerLabel);
     }
 
+    public String getAdditionalRunArgs() {
+        return Util.fixNull(additionalRunArgs);
+    }
+
     @DataBoundSetter
     public void setDockerLabel(String dockerLabel) {
         this.dockerLabel = dockerLabel;
+    }
+
+    @DataBoundSetter
+    public void setAdditionalRunArgs(String additionalRunArgs) {
+        this.additionalRunArgs = additionalRunArgs;
     }
 
     public DockerRegistryEndpoint getRegistry() {
@@ -112,6 +122,11 @@ public class GlobalConfig extends GlobalConfiguration {
         @Override
         public String getLabel(@Nullable Run run) {
             return config.getDockerLabel();
+        }
+
+        @Override
+        public String getAdditionalRunArgs(@Nullable Run run) {
+            return config.getAdditionalRunArgs();
         }
 
         @Override

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/FolderConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/FolderConfig/config.groovy
@@ -31,4 +31,7 @@ def f = namespace(lib.FormTagLib)
 f.entry(field: "dockerLabel", title: _("Docker Label")) {
     f.textbox()
 }
+f.entry(field: "additionalRunArgs", title:_("Docker Additional Run Arguments")) {
+    f.textbox()
+}
 f.property(field: "registry")

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/GlobalConfig/config.groovy
@@ -32,5 +32,8 @@ f.section(title:_("Declarative Pipeline (Docker)")) {
     f.entry(field: "dockerLabel", title:_("Docker Label")) {
         f.textbox()
     }
+    f.entry(field: "additionalRunArgs", title:_("Docker Additional Run Arguments")) {
+        f.textbox()
+    }
     f.property(field: "registry")
 }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/declarative/DeclarativeDockerUtilsTest.java
@@ -70,8 +70,10 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
         Assume.assumeFalse("Fails using the version of Git installed on the Windows ACI agents on ci.jenkins.io", Functions.isWindows());
         GlobalConfig.get().setDockerLabel("config_docker");
         GlobalConfig.get().setRegistry(new DockerRegistryEndpoint("https://docker.registry", globalCred.getId()));
+        GlobalConfig.get().setAdditionalRunArgs("-v /tmp:/tmptest:ro,z");
         expect("org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig")
                 .logContains("Docker Label is: config_docker",
+                        "Docker Run Additional Arguments are: -v /tmp:/tmptest:ro,z",
                         "Registry URL is: https://docker.registry",
                         "Registry Creds ID is: " + globalCred.getId()).go();
     }
@@ -88,11 +90,12 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
     public void directParent() throws Exception {
         Folder folder = j.createProject(Folder.class);
         getFolderStore(folder).addCredentials(Domain.global(), folderCred);
-        folder.addProperty(new FolderConfig("folder_docker", "https://folder.registry", folderCred.getId()));
+        folder.addProperty(new FolderConfig("folder_docker", "", "https://folder.registry", folderCred.getId()));
         expect("org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig")
                 .inFolder(folder)
                 .runFromRepo(false)
                 .logContains("Docker Label is: folder_docker",
+                        "Docker Run Additional Arguments are: ",
                         "Registry URL is: https://folder.registry",
                         "Registry Creds ID is: " + folderCred.getId()).go();
     }
@@ -102,11 +105,12 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
         Folder folder = j.createProject(Folder.class);
         getFolderStore(folder).addCredentials(Domain.global(), folderCred);
         getFolderStore(folder).addCredentials(Domain.global(), grandParentCred);
-        folder.addProperty(new FolderConfig("folder_docker", "https://folder.registry", folderCred.getId()));
+        folder.addProperty(new FolderConfig("folder_docker", "", "https://folder.registry", folderCred.getId()));
         expect("org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfigWithOverride")
                 .inFolder(folder)
                 .runFromRepo(false)
                 .logContains("Docker Label is: other-label",
+                        "Docker Run Additional Arguments are: ",
                         "Registry URL is: https://other.registry",
                         "Registry Creds ID is: " + grandParentCred.getId()).go();
     }
@@ -114,17 +118,20 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
     @Test
     public void directParentNotSystem() throws Exception {
         GlobalConfig.get().setDockerLabel("config_docker");
+        GlobalConfig.get().setAdditionalRunArgs("-v /tmp:/tmp1:ro,z");
         GlobalConfig.get().setRegistry(new DockerRegistryEndpoint("https://docker.registry", globalCred.getId()));
         Folder folder = j.createProject(Folder.class);
         getFolderStore(folder).addCredentials(Domain.global(), folderCred);
-        folder.addProperty(new FolderConfig("folder_docker", "https://folder.registry", folderCred.getId()));
+        folder.addProperty(new FolderConfig("folder_docker", "-v /tmp:/tmp2:ro,z", "https://folder.registry", folderCred.getId()));
         expect("org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig")
                 .inFolder(folder)
                 .runFromRepo(false)
                 .logContains("Docker Label is: folder_docker",
+                        "Docker Run Additional Arguments are: -v /tmp:/tmp2:ro,z",
                         "Registry URL is: https://folder.registry",
                         "Registry Creds ID is: " + folderCred.getId())
                 .logNotContains("Docker Label is: config_docker",
+                        "Docker Run Additional Arguments are: -v /tmp:/tmp1:ro,z",
                         "Registry URL is: https://docker.registry",
                         "Registry Creds ID is: " + globalCred.getId()).go();
     }
@@ -133,12 +140,13 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
     public void grandParent() throws Exception {
         Folder grandParent = j.createProject(Folder.class);
         getFolderStore(grandParent).addCredentials(Domain.global(), grandParentCred);
-        grandParent.addProperty(new FolderConfig("parent_docker", "https://parent.registry", grandParentCred.getId()));
+        grandParent.addProperty(new FolderConfig("parent_docker", "", "https://parent.registry", grandParentCred.getId()));
         Folder parent = grandParent.createProject(Folder.class, "testParent"); //Can be static since grandParent should be unique
         expect("org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig")
                 .inFolder(parent)
                 .runFromRepo(false)
                 .logContains("Docker Label is: parent_docker",
+                        "Docker Run Additional Arguments are: ",
                         "Registry URL is: https://parent.registry",
                         "Registry Creds ID is: " + grandParentCred.getId()).go();
     }
@@ -147,18 +155,20 @@ public class DeclarativeDockerUtilsTest extends AbstractModelDefTest {
     public void grandParentOverride() throws Exception {
         Folder grandParent = j.createProject(Folder.class);
         getFolderStore(grandParent).addCredentials(Domain.global(), grandParentCred);
-        grandParent.addProperty(new FolderConfig("parent_docker", "https://parent.registry", grandParentCred.getId()));
+        grandParent.addProperty(new FolderConfig("parent_docker", "-v /tmp:/tmp1:ro,z", "https://parent.registry", grandParentCred.getId()));
         Folder parent = grandParent.createProject(Folder.class, "testParent"); //Can be static since grandParent should be unique
         getFolderStore(parent).addCredentials(Domain.global(), folderCred);
-        parent.addProperty(new FolderConfig("folder_docker", "https://folder.registry", folderCred.getId()));
+        parent.addProperty(new FolderConfig("folder_docker", "-v /tmp:/tmp2:ro,z", "https://folder.registry", folderCred.getId()));
 
         expect("org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig")
                 .inFolder(parent)
                 .runFromRepo(false)
                 .logContains("Docker Label is: folder_docker",
+                        "Docker Run Additional Arguments are: -v /tmp:/tmp2:ro,z",
                         "Registry URL is: https://folder.registry",
                         "Registry Creds ID is: " + folderCred.getId())
                 .logNotContains("Docker Label is: parent_docker",
+                        "Docker Run Additional Arguments are: -v /tmp:/tmp1:ro,z",
                         "Registry URL is: https://parent.registry",
                         "Registry Creds ID is: " + grandParentCred.getId()).go();
     }

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfig.groovy
@@ -26,5 +26,6 @@ import org.jenkinsci.plugins.docker.workflow.declarative.DeclarativeDockerUtils
 
 
 echo "Docker Label is: ${DeclarativeDockerUtils.getLabel()}"
+echo "Docker Run Additional Arguments are: ${DeclarativeDockerUtils.getAdditionalRunArgs()}"
 echo "Registry URL is: ${DeclarativeDockerUtils.getRegistryUrl()}"
 echo "Registry Creds ID is: ${DeclarativeDockerUtils.getRegistryCredentialsId()}"

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfigWithOverride.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/declarativeDockerConfigWithOverride.groovy
@@ -25,5 +25,6 @@
 import org.jenkinsci.plugins.docker.workflow.declarative.DeclarativeDockerUtils
 
 echo "Docker Label is: ${DeclarativeDockerUtils.getLabel('other-label')}"
+echo "Docker Run Additional Arguments are: ${DeclarativeDockerUtils.getAdditionalRunArgs()}"
 echo "Registry URL is: ${DeclarativeDockerUtils.getRegistryUrl('https://other.registry')}"
 echo "Registry Creds ID is: ${DeclarativeDockerUtils.getRegistryCredentialsId('grandParentCreds')}"


### PR DESCRIPTION
### Why this pull request ?

This pull request enable Jenkins adminstrator (or users) to add specific arguments to each `docker run` commands issued by the plugin to the underlying Docker Pipeline node.

#### Context

At $daywork, we are migrating from an old DCOS infrastructure, with DIND containers having access to the Docker Socket, to Kubernetes DIND containers (without Docker Socket access).

DCOS DIND containers automatically remount *all* volumes, including a TLS CA bundle that is provided to the Docker Pipeline Node.
On Kubernetes, the volumes is not found (as there is no volume found for the container exposed through the DIND without a shared socket), so we needed a way to append specific args to each `docker run` command as such : `-v /etc/ssl/certs/tls-ca-bundle.pem:/etc/ssl/certs/tls-ca-bundle.pem:ro,z` (The TLS CA bundle is exposed to the DIND container by Kubernetes through a config map).

This enable us to migrate our infrastructure without having to ask our numerous users to append an "args: ..." to all of their pipelines' code.

### Testing done

Modified current tests to check for Global and Folder config / overrides.

Currently opened to our internal user base in beta befor pushing to our production infrastructure.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
