### PR TITLE
`docker stop --time` increased to 5 seconds

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -182,7 +182,7 @@ public class DockerClient {
      * @param containerId The container ID.
      */
     public void stop(@NonNull EnvVars launchEnv, @NonNull String containerId) throws IOException, InterruptedException {
-        LaunchResult result = launch(launchEnv, false, "stop", "--time=1", containerId);
+        LaunchResult result = launch(launchEnv, false, "stop", "--time=5", containerId);
         if (result.getStatus() != 0) {
             throw new IOException(String.format("Failed to kill container '%s'.", containerId));
         }


### PR DESCRIPTION
When my company's (Windows) build infrastructure is under heavy load, Jenkins pipelines start failing because Docker containers cannot be stopped in 1 second:

```
java.io.IOException: Failed to kill container '84ed22ea737f82f2e0a51e813cc9b807c6a48f7154ebffc360ca365fd27ed248'.
12:04:11  	at org.jenkinsci.plugins.docker.workflow.client.DockerClient.stop(DockerClient.java:184)
```

5 seconds should be a more reasonable timeout.

Alternatively, the timeout should be exposed as a config option.

<!-- Please describe your pull request here. -->

### Testing done

No testing was done.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
