### PR TITLE
Run containers with --init by default to avoid leaking zombie processes.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -116,7 +116,7 @@ public class DockerClient {
     public String run(@NonNull EnvVars launchEnv, @NonNull String image, @CheckForNull String args, @CheckForNull String workdir, @NonNull Map<String, String> volumes, @NonNull Collection<String> volumesFromContainers, @NonNull EnvVars containerEnv, @NonNull String user, @NonNull String... command) throws IOException, InterruptedException {
         ArgumentListBuilder argb = new ArgumentListBuilder();
 
-        argb.add("run", "-t", "-d");
+        argb.add("run", "-t", "-d", "--init");
 
         // Username might be empty because we are running on Windows
         if (StringUtils.isNotEmpty(user)) {


### PR DESCRIPTION
People running containers manually usually run with pid 1 being a $SHELL, in which case waiting for child termination is something implemented already as it's the core job of a $SHELL. However with this jenkins plugin the command run is usually "cat" on Linux, which doesn't wait at all for children. To have in jenkins a situation a bit like during interactive container experience, start containers with --init so zombie processes are correctly reaped.
### Testing done

Not done yet.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```