### PR TITLE
Migrate tests to the very latest httpd docker image to unbreak tests.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerDSLTest.java
@@ -113,7 +113,7 @@ public class DockerDSLTest {
                 assumeDocker();
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
-                    "def r = docker.image('httpd:2.4.12').inside {\n" +
+                    "def r = docker.image('httpd:2.4.59').inside {\n" +
                     "  semaphore 'wait'\n" +
                     "  sh 'cat /usr/local/apache2/conf/extra/httpd-userdir.conf'\n" +
                     "  42\n" +
@@ -185,7 +185,7 @@ public class DockerDSLTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +
-                    "  def img = docker.image('httpd:2.4.12')\n" +
+                    "  def img = docker.image('httpd:2.4.59')\n" +
                     "  img.run().stop()\n" +
                     "  img.run('--memory-swap=-1').stop()\n" +
                     "  img.withRun {}\n" +
@@ -204,7 +204,7 @@ public class DockerDSLTest {
                 assumeDocker();
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
-                    "def r = docker.image('httpd:2.4.12').withRun {c ->\n" +
+                    "def r = docker.image('httpd:2.4.59').withRun {c ->\n" +
                     "  semaphore 'wait'\n" +
                     "  sh \"docker exec ${c.id} cat /usr/local/apache2/conf/extra/httpd-userdir.conf\"\n" +
                     "  42\n" +
@@ -346,7 +346,7 @@ public class DockerDSLTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
                 "docker.withTool('default') {\n" +
-                "  docker.image('httpd:2.4.12').withRun {}\n" +
+                "  docker.image('httpd:2.4.59').withRun {}\n" +
                 "  sh 'echo PATH=$PATH'\n" +
                 "}", true));
                 story.j.assertLogContains("PATH=/usr/bin:", story.j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
@@ -437,7 +437,7 @@ public class DockerDSLTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +
-                        "  def img = docker.image('httpd:2.4.12')\n" +
+                        "  def img = docker.image('httpd:2.4.59')\n" +
                         "  def port = img.withRun('-p 12345:80') { c -> c.port(80) }\n" +
                         "  echo \"container running on ${port}\"" +
                     "}", true));

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -111,7 +111,7 @@ public class WithContainerStepTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +
-                    "  withDockerContainer('httpd:2.4.12') {\n" +
+                    "  withDockerContainer('httpd:2.4.59') {\n" +
                     "    sh 'cp /usr/local/apache2/conf/extra/httpd-userdir.conf .; ls -la'\n" +
                     "  }\n" +
                     "  sh 'ls -la; cat *.conf'\n" +
@@ -135,7 +135,7 @@ public class WithContainerStepTest {
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +
                     "  timeout(time: 20, unit: 'SECONDS') {\n" +
-                    "    withDockerContainer('httpd:2.4.12') {\n" +
+                    "    withDockerContainer('httpd:2.4.59') {\n" +
                     "      sh 'sleep infinity'\n" +
                     "    }\n" +
                     "  }\n" +
@@ -215,7 +215,7 @@ public class WithContainerStepTest {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
                 p.setDefinition(new CpsFlowDefinition(
                     "node {\n" +
-                    "  withDockerContainer('httpd:2.4.12') {\n" +
+                    "  withDockerContainer('httpd:2.4.59') {\n" +
                     "    semaphore 'wait'\n" +
                     "    sh 'cat /usr/local/apache2/conf/extra/httpd-userdir.conf'\n" +
                     "  }\n" +
@@ -481,7 +481,7 @@ public class WithContainerStepTest {
             p.setDefinition(new CpsFlowDefinition(
                 "node('dockerized') {\n" +
                 "  sh 'which docker && docker version'\n" +
-                "  withDockerContainer('httpd:2.4.12') {\n" +
+                "  withDockerContainer('httpd:2.4.59') {\n" +
                 "    sh 'cp /usr/local/apache2/conf/extra/httpd-userdir.conf .; ls -la'\n" +
                 "  }\n" +
                 "  sh 'ls -la; cat *.conf'\n" +

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/WindowsDockerClientTest.java
@@ -32,7 +32,7 @@ public class WindowsDockerClientTest {
         EnvVars launchEnv = DockerTestUtil.newDockerLaunchEnv();
         String containerId = dockerClient.run(
             launchEnv,
-            "learn/tutorial",
+            "busybox",
             null,
             null,
             Collections.emptyMap(),
@@ -43,7 +43,7 @@ public class WindowsDockerClientTest {
 
         Assert.assertEquals(64, containerId.length());
         ContainerRecord containerRecord = dockerClient.getContainerRecord(launchEnv, containerId);
-        Assert.assertEquals(dockerClient.inspect(launchEnv, "learn/tutorial", ".Id"), containerRecord.getImageId());
+        Assert.assertEquals(dockerClient.inspect(launchEnv, "busybox", ".Id"), containerRecord.getImageId());
         Assert.assertTrue(containerRecord.getContainerName().length() > 0);
         Assert.assertTrue(containerRecord.getHost().length() > 0);
         Assert.assertTrue(containerRecord.getCreated() > 1000000000000L);

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDocker.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDocker.groovy
@@ -25,7 +25,7 @@
 pipeline {
     agent {
         docker {
-            image "httpd:2.4.12"
+            image "httpd:2.4.59"
             args "-v /tmp:/tmp"
         }
     }

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDocker.json
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDocker.json
@@ -34,7 +34,7 @@
         "key": "image",
         "value":         {
           "isLiteral": true,
-          "value": "httpd:2.4.12"
+          "value": "httpd:2.4.59"
         }
       },
             {

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerContainerPerStage.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerContainerPerStage.groovy
@@ -25,7 +25,7 @@
 pipeline {
     agent {
         docker {
-            image "httpd:2.4.12"
+            image "httpd:2.4.59"
             label "docker"
         }
     }

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerDontReuseNode.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerDontReuseNode.groovy
@@ -40,7 +40,7 @@ pipeline {
             agent {
                 docker {
                     label "other-docker"
-                    image "httpd:2.4.12"
+                    image "httpd:2.4.59"
                     reuseNode true
                 }
             }

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerEnvSpecLabel.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerEnvSpecLabel.groovy
@@ -30,7 +30,7 @@ pipeline {
     agent {
         docker {
             label "thisspec"
-            image "httpd:2.4.12"
+            image "httpd:2.4.59"
             args "-v /tmp:/tmp"
         }
     }

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerEnvTest.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerEnvTest.groovy
@@ -29,7 +29,7 @@
 pipeline {
     agent {
         docker {
-            image "httpd:2.4.12"
+            image "httpd:2.4.59"
             args "-v /tmp:/tmp"
         }
     }

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerReuseNode.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerReuseNode.groovy
@@ -37,7 +37,7 @@ pipeline {
         stage("bar") {
             agent {
                 docker {
-                    image "httpd:2.4.12"
+                    image "httpd:2.4.59"
                     reuseNode true
                 }
             }

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithCreds.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithCreds.groovy
@@ -27,7 +27,7 @@ pipeline {
         docker {
             alwaysPull true
             registryCredentialsId "dockerhub"
-            image "jtaboada/httpd:2.4.12"
+            image "jtaboada/httpd:2.4.59"
             args "-v /tmp:/tmp"
         }
     }

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithEmptyDockerArgs.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithEmptyDockerArgs.groovy
@@ -25,7 +25,7 @@
 pipeline {
     agent {
         docker {
-            image "httpd:2.4.12"
+            image "httpd:2.4.59"
             args ""
         }
     }

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithNullDockerArgs.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithNullDockerArgs.groovy
@@ -25,7 +25,7 @@
 pipeline {
     agent {
         docker {
-            image "httpd:2.4.12"
+            image "httpd:2.4.59"
             args null
         }
     }

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithRegistryNoCreds.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithRegistryNoCreds.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent {
         docker {
             alwaysPull true
-            image "httpd:2.4.12"
+            image "httpd:2.4.59"
             registryUrl "https://index.docker.io/v2/"
             args "-v /tmp:/tmp"
         }

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithoutContainerPerStage.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentDockerWithoutContainerPerStage.groovy
@@ -25,7 +25,7 @@
 pipeline {
     agent {
         docker {
-            image "httpd:2.4.12"
+            image "httpd:2.4.59"
             label "docker"
         }
     }

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentInStageAutoCheckout.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/agentInStageAutoCheckout.groovy
@@ -37,7 +37,7 @@ pipeline {
         stage("bar") {
             agent {
                 docker {
-                    image "httpd:2.4.12"
+                    image "httpd:2.4.59"
                     reuseNode true
                 }
             }
@@ -50,7 +50,7 @@ pipeline {
         stage("new node - docker") {
             agent {
                 docker {
-                    image "httpd:2.4.12"
+                    image "httpd:2.4.59"
                 }
             }
             steps {

--- a/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/nonExistentDockerImage.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/docker/workflow/declarative/nonExistentDockerImage.groovy
@@ -25,7 +25,7 @@
 pipeline {
     agent {
         docker {
-            image "httpdIDontExist:2.4.12"
+            image "httpdIDontExist:2.4.59"
             args "-v /tmp:/tmp"
         }
     }


### PR DESCRIPTION
Indeed since Docker 26 the image in the old v1 format are no longer run by default (it used to be deprecated but tolerated for years). Fix this by hardcoding the very latest httpd docker image version as of today.

If you are interested by the actual deprecation description on docker side, it's this one: https://docs.docker.com/engine/deprecated/#pushing-and-pulling-with-image-manifest-v2-schema-1

If fixes errors like this that we have with the current non-regressions tests (extracted from your CI: https://ci.jenkins.io/job/Plugins/job/docker-workflow-plugin/job/PR-312/1/pipeline-console/?selected-node=33)

```
10:52:10  [Pipeline] withEnv
10:52:10  [Pipeline] {
10:52:10  [Pipeline] sh
10:52:10  + docker inspect -f . httpd:2.4.12
10:52:10  
10:52:10  Error: No such object: httpd:2.4.12
10:52:10  [Pipeline] isUnix
10:52:10  [Pipeline] withEnv
10:52:10  [Pipeline] {
10:52:10  [Pipeline] sh
10:52:10  + docker pull httpd:2.4.12
10:52:10  2.4.12: Pulling from library/httpd
10:52:10  [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/library/httpd:2.4.12 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
10:52:10  [Pipeline] }
10:52:10  [Pipeline] // withEnv
10:52:10  [Pipeline] }
10:52:10  [Pipeline] // withEnv
10:52:10  [Pipeline] }
10:52:10  [Pipeline] // node
10:52:10  [Pipeline] End of Pipeline
10:52:10  ERROR: script returned exit code 1
10:52:10  Finished: FAILURE
```

I need this as a pre-requisite for another of my pull requests, but this is independant from my other change.

### Testing done

Testing done via your own CI.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
