### PR TITLE
Use docker ps to detect absence of docker permissions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/DockerTestUtil.java
@@ -74,8 +74,14 @@ public class DockerTestUtil {
     public static void assumeDocker(DockerOsMode osMode, VersionNumber minimumVersion) throws Exception {
         Launcher.LocalLauncher localLauncher = new Launcher.LocalLauncher(StreamTaskListener.NULL);
         try {
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
             int status = localLauncher
+                .launch()
+                .cmds(DockerTool.getExecutable(null, null, null, null), "ps")
+                .start()
+                .joinWithTimeout(DockerClient.CLIENT_TIMEOUT, TimeUnit.SECONDS, localLauncher.getListener());
+            Assume.assumeTrue("Docker working", status == 0);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            status = localLauncher
                 .launch()
                 .cmds(DockerTool.getExecutable(null, null, null, null), "version", "-f", "{{.Server.Os}}")
                 .stdout(out)


### PR DESCRIPTION
## Use `docker ps` to detect absence of docker permissions

The plugin BOM agents seem to have the `docker` command available but the user running the agent is not authorized to use the `docker` command.  Previously that was detected by calling `docker ps` and detecting the failure.

Restores a change made in

* https://github.com/jenkinsci/docker-workflow-plugin/pull/331

### Testing done

Plugin BOM draft pull request to check it on weekly:

* https://github.com/jenkinsci/bom/pull/4473

Confirmed that I could see the same failure on a local computer as is seen on https://ci.jenkins.io/job/Tools/job/bom/job/master/3968/testReport/org.jenkinsci.plugins.docker.workflow/DockerDSLTest/

The computer had Docker CE installed by the specific user running the test did not have permission to access Docker.  Prior to this change, the tests failed with the message:

```
CANNOT CONNECT TO THE DOCKER DAEMON AT UNIX:///VAR/RUN/DOCKER.SOCK. IS THE DOCKER DAEMON RUNNING?
```

After making this change, the tests pass on that computer with the specific user that does not have permission to access Docker.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
