### PR TITLE
Adapt to Declarative change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,9 @@
         <changelist>999999-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <!-- TODO until in BOM -->
+        <pipeline-model-definition.version>2.2234.v4a_b_13b_8cd590</pipeline-model-definition.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <repositories>
@@ -52,9 +54,35 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3893.v213a_42768d35</version>
+                <version>4228.v0a_71308d905b_</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkinsci.plugins</groupId>
+                <artifactId>pipeline-model-api</artifactId>
+                <version>${pipeline-model-definition.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkinsci.plugins</groupId>
+                <artifactId>pipeline-model-definition</artifactId>
+                <version>${pipeline-model-definition.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkinsci.plugins</groupId>
+                <artifactId>pipeline-model-definition</artifactId>
+                <version>${pipeline-model-definition.version}</version>
+                <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkinsci.plugins</groupId>
+                <artifactId>pipeline-model-extensions</artifactId>
+                <version>${pipeline-model-definition.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkinsci.plugins</groupId>
+                <artifactId>pipeline-stage-tags-metadata</artifactId>
+                <version>${pipeline-model-definition.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfileScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfileScript.groovy
@@ -56,7 +56,7 @@ class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineScript<Do
         }
     }
 
-    private void buildImage() {
+    private def buildImage() {
         boolean isUnix = script.isUnix()
         def dockerfilePath = describable.getDockerfilePath(isUnix)
         try {

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfileScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineFromDockerfileScript.groovy
@@ -37,49 +37,43 @@ class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineScript<Do
     }
 
     @Override
-    Closure runImage(Closure body) {
-        return {
-            def img = null
-            if (!Utils.withinAStage()) {
-                script.stage(SyntheticStageNames.agentSetup()) {
-                    try {
-                        img = buildImage().call()
-                    } catch (Exception e) {
-                        Utils.markStageFailedAndContinued(SyntheticStageNames.agentSetup())
-                        throw e
-                    }
+    void runImage(Closure body) {
+        def img = null
+        if (!Utils.withinAStage()) {
+            script.stage(SyntheticStageNames.agentSetup()) {
+                try {
+                    img = buildImage()
+                } catch (Exception e) {
+                    Utils.markStageFailedAndContinued(SyntheticStageNames.agentSetup())
+                    throw e
                 }
-            } else {
-                img = buildImage().call()
             }
-            if (img != null) {
-                img.inside(describable.args, {
-                    body.call()
-                })
-            }
+        } else {
+            img = buildImage()
+        }
+        if (img != null) {
+            img.inside(describable.args, body)
         }
     }
 
-    private Closure buildImage() {
-        return {
-            boolean isUnix = script.isUnix()
-            def dockerfilePath = describable.getDockerfilePath(isUnix)
-            try {
-                RunWrapper runWrapper = (RunWrapper)script.getProperty("currentBuild")
-                def additionalBuildArgs = describable.getAdditionalBuildArgs() ? " ${describable.additionalBuildArgs}" : ""
-                def hash = Utils.stringToSHA1("${runWrapper.fullProjectName}\n${script.readFile("${dockerfilePath}")}\n${additionalBuildArgs}")
-                def imgName = "${hash}"
-                def commandLine = "docker build -t ${imgName}${additionalBuildArgs} -f \"${dockerfilePath}\" \"${describable.getActualDir()}\""
-                if (isUnix)
-                    script.sh commandLine
-                else
-                    script.bat commandLine
+    private void buildImage() {
+        boolean isUnix = script.isUnix()
+        def dockerfilePath = describable.getDockerfilePath(isUnix)
+        try {
+            RunWrapper runWrapper = (RunWrapper)script.getProperty("currentBuild")
+            def additionalBuildArgs = describable.getAdditionalBuildArgs() ? " ${describable.additionalBuildArgs}" : ""
+            def hash = Utils.stringToSHA1("${runWrapper.fullProjectName}\n${script.readFile("${dockerfilePath}")}\n${additionalBuildArgs}")
+            def imgName = "${hash}"
+            def commandLine = "docker build -t ${imgName}${additionalBuildArgs} -f \"${dockerfilePath}\" \"${describable.getActualDir()}\""
+            if (isUnix)
+                script.sh commandLine
+            else
+                script.bat commandLine
 
-                return script.getProperty("docker").image(imgName)
-            } catch (FileNotFoundException f) {
-                script.error("No Dockerfile found at ${dockerfilePath} in repository - failing.")
-                return null
-            }
+            return script.getProperty("docker").image(imgName)
+        } catch (FileNotFoundException f) {
+            script.error("No Dockerfile found at ${dockerfilePath} in repository - failing.")
+            return null
         }
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineScript.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/docker/workflow/declarative/DockerPipelineScript.groovy
@@ -36,24 +36,20 @@ class DockerPipelineScript extends AbstractDockerPipelineScript<DockerPipeline> 
     }
 
     @Override
-    Closure runImage(Closure body) {
-        return {
-            if (!Utils.withinAStage() && describable.alwaysPull) {
-                script.stage(SyntheticStageNames.agentSetup()) {
-                    try {
-                        script.getProperty("docker").image(describable.image).pull()
-                    } catch (Exception e) {
-                        Utils.markStageFailedAndContinued(SyntheticStageNames.agentSetup())
-                        throw e
-                    }
+    void runImage(Closure body) {
+        if (!Utils.withinAStage() && describable.alwaysPull) {
+            script.stage(SyntheticStageNames.agentSetup()) {
+                try {
+                    script.getProperty("docker").image(describable.image).pull()
+                } catch (Exception e) {
+                    Utils.markStageFailedAndContinued(SyntheticStageNames.agentSetup())
+                    throw e
                 }
             }
-            if (Utils.withinAStage() && describable.alwaysPull) {
-                script.getProperty("docker").image(describable.image).pull()
-            }
-            script.getProperty("docker").image(describable.image).inside(describable.args, {
-                body.call()
-            })
         }
+        if (Utils.withinAStage() && describable.alwaysPull) {
+            script.getProperty("docker").image(describable.image).pull()
+        }
+        script.getProperty("docker").image(describable.image).inside(describable.args, body)
     }
 }


### PR DESCRIPTION
Adapts to https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/762, which is unfortunately incompatible in that `DeclarativeDockerUtils.getLabelScript` is going to return a new type of object. (Due to the complex mixture of CPS-transformed Groovy sources and Java APIs, it did not seem feasible to make that a compatible change.)