### PR TITLE
JENKINS-63628: Handle "process leaked file descriptors" issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,12 @@
             <version>1.21.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.18.0</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Required because git plugin optionally depends on a recent version of matrix-project, and if we do not depend
         on matrix-project here, an older version is installed automatically as a detached plugin, causing git plugin to fail to load. -->
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -143,7 +143,10 @@ public class DockerClient {
 
         LaunchResult result = launch(launchEnv, false, null, argb);
         if (result.getStatus() == 0) {
-            return result.getOut();
+            // Take only the first line containing the container ID.
+            // Otherwise, we might capture the "leaked file descriptors" message.
+            // See https://issues.jenkins.io/browse/JENKINS-63628 for more info.
+            return result.getOut().split("\n")[0];
         } else {
             throw new IOException(String.format("Failed to run image '%s'. Error: %s", image, result.getErr()));
         }

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientUnitTest.java
@@ -1,0 +1,64 @@
+package org.jenkinsci.plugins.docker.workflow.client;
+
+import hudson.EnvVars;
+import hudson.Launcher;
+import hudson.Proc;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+public class DockerClientUnitTest {
+    private DockerClient dockerClient;
+    private Launcher launcher;
+
+    @Before
+    public void setup() throws Exception {
+        launcher = Mockito.mock(Launcher.class);
+        dockerClient = new DockerClient(launcher, null, null);
+    }
+
+
+    @Test
+    public void test_run() throws IOException, InterruptedException {
+        var output = "ee632b4c84ed5aaea15608d5180169dfc7eedeaf7021a6724232e61c1f4d5d4c";
+        Launcher.ProcStarter procStarter = launcher.new ProcStarter();
+        Mockito.when(launcher.launch()).thenReturn(procStarter);
+        Proc proc = Mockito.mock(Proc.class);
+        Mockito.when(launcher.launch(procStarter)).thenAnswer(input -> {
+            procStarter.stdout().write(output.getBytes(StandardCharsets.UTF_8));
+            return proc;
+        });
+        Mockito.when(proc.joinWithTimeout(Mockito.anyLong(), Mockito.any(), Mockito.any())).thenReturn(0);
+
+        String containerId =
+            dockerClient.run(new EnvVars(), "test-image", null, null, Collections.<String, String>emptyMap(), Collections.<String>emptyList(), new EnvVars(),
+                dockerClient.whoAmI(), "cat");
+
+        Assert.assertEquals("ee632b4c84ed5aaea15608d5180169dfc7eedeaf7021a6724232e61c1f4d5d4c", containerId);
+    }
+
+    @Test
+    public void test_leaked_descriptors() throws IOException, InterruptedException {
+        // See https://issues.jenkins.io/browse/JENKINS-63628
+        var output = "ee632b4c84ed5aaea15608d5180169dfc7eedeaf7021a6724232e61c1f4d5d4c\nProcess leaked file descriptors. See https://jenkins.io/redirect/troubleshooting/process-leaked-file-descriptors for more information";
+        Launcher.ProcStarter procStarter = launcher.new ProcStarter();
+        Mockito.when(launcher.launch()).thenReturn(procStarter);
+        Proc proc = Mockito.mock(Proc.class);
+        Mockito.when(launcher.launch(procStarter)).thenAnswer(input -> {
+            procStarter.stdout().write(output.getBytes(StandardCharsets.UTF_8));
+            return proc;
+        });
+        Mockito.when(proc.joinWithTimeout(Mockito.anyLong(), Mockito.any(), Mockito.any())).thenReturn(0);
+
+        String containerId =
+            dockerClient.run(new EnvVars(), "test-image", null, null, Collections.<String, String>emptyMap(), Collections.<String>emptyList(), new EnvVars(),
+                dockerClient.whoAmI(), "cat");
+
+        Assert.assertEquals("ee632b4c84ed5aaea15608d5180169dfc7eedeaf7021a6724232e61c1f4d5d4c", containerId);
+    }
+}


### PR DESCRIPTION
This PR proposes a fix for the occasional `Process leaked file descriptors` issue with this plugin. Please see [my comment](https://issues.jenkins.io/browse/JENKINS-63628?focusedId=453552&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-453552) for the research into this failure and any relevant prior art. It should fix [JENKINS-63628](https://issues.jenkins.io/browse/JENKINS-63628).
<!-- Please describe your pull request here. -->

### Testing done

I've added unit tests for this change, and these passed locally ✅ 

The tests in the current repo are system/integration tests, but (given the nature of the issue) I could not write a system test that reliably reproduces this. This is why this PR adds `mockito` dependency and a pair of unit tests to verify this functionality. 
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x]  Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
