### PR TITLE
Exclude useless `gradle` test dependency (fix typo)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.jenkins-ci.plugin</groupId>
+                    <groupId>org.jenkins-ci.plugins</groupId>
                     <artifactId>gradle</artifactId>
                 </exclusion>
             </exclusions>


### PR DESCRIPTION
`jenkins-test-harness-tools` depends on `gradle:2.15`. This causes an issue when running PCT on megawar containing `docker-workflow-plugin` and `gradle:2.16.1149.v711b_998b_0532` (see [JENKINS-76087](https://issues.jenkins.io/browse/JENKINS-76087)).

Follow-up of https://github.com/jenkinsci/docker-workflow-plugin/pull/365

This fixes a typo (the exclusion was ineffective).

### Testing done

`mvn dependency:tree | grep gradle` has empty result.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
