### PR TITLE
Make docker stop timeout configurable via STOP_TIMEOUT property

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -86,6 +86,13 @@ public class DockerClient {
     @Restricted(NoExternalUse.class)
     public static boolean SKIP_RM_ON_STOP = Boolean.getBoolean(DockerClient.class.getName() + ".SKIP_RM_ON_STOP");
 
+    /**
+     * Number of seconds to wait for a container to stop gracefully before sending SIGKILL.
+     */
+    @SuppressFBWarnings(value="MS_SHOULD_BE_FINAL", justification="mutable for scripts")
+    @Restricted(NoExternalUse.class)
+    public static int STOP_TIMEOUT = Integer.getInteger(DockerClient.class.getName() + ".STOP_TIMEOUT", 1);
+
     // e.g. 2015-04-09T13:40:21.981801679Z
     public static final String DOCKER_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
     
@@ -182,7 +189,7 @@ public class DockerClient {
      * @param containerId The container ID.
      */
     public void stop(@NonNull EnvVars launchEnv, @NonNull String containerId) throws IOException, InterruptedException {
-        LaunchResult result = launch(launchEnv, false, "stop", "--time=1", containerId);
+        LaunchResult result = launch(launchEnv, false, "stop", "-t", String.valueOf(STOP_TIMEOUT), containerId);
         if (result.getStatus() != 0) {
             throw new IOException(String.format("Failed to kill container '%s'.", containerId));
         }


### PR DESCRIPTION
The `--time` argument to `docker stop` was previously hardcoded and could
not be adjusted for containers that need more time to shut down gracefully.
Modern Docker has also deprecated `--time` in favour of `--timeout`, though
the `--timeout` long form was only introduced in Docker 23 and is not
recognised by older clients.

Add a static `STOP_TIMEOUT` field consistent with the existing
`CLIENT_TIMEOUT` and `SKIP_RM_ON_STOP` fields, and switch to the short
`-t` flag which maps to the timeout parameter on all Docker client versions
without deprecation warnings. The value can be overridden via the system
property:
  `org.jenkinsci.plugins.docker.workflow.client.DockerClient.STOP_TIMEOUT`
or mutated from a Groovy init script at runtime.

Fixes https://github.com/jenkinsci/docker-workflow-plugin/issues/733
Related to https://github.com/jenkinsci/docker-workflow-plugin/issues/719

### Testing done

Ran `DockerClientTest#test_run` against a live Docker daemon with the default timeout (1 s)
and with an override of 5 s.

Default (`STOP_TIMEOUT=1`):

    $ docker run -t -d -u 1000:1000 docker.io/library/docker@sha256:d842418d21545fde57c2512681d9bdc4ce0e54f2e0305a293ee20a9b6166932b cat
    $ docker stop -t 1 091b9b67a08261b65a7e6f99ba1c8dba0845acff33b2d5a764e0d4cc68f4555d
    $ docker rm -f --volumes 091b9b67a08261b65a7e6f99ba1c8dba0845acff33b2d5a764e0d4cc68f4555d
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.248 s

Override (`-Dorg.jenkinsci.plugins.docker.workflow.client.DockerClient.STOP_TIMEOUT=5`):

    $ docker run -t -d -u 1000:1000 docker.io/library/docker@sha256:d842418d21545fde57c2512681d9bdc4ce0e54f2e0305a293ee20a9b6166932b cat
    $ docker stop -t 5 c8591c3f5f5757389f98b7e24724df6879ca792652fc196191937fba3d9ce06e
    $ docker rm -f --volumes c8591c3f5f5757389f98b7e24724df6879ca792652fc196191937fba3d9ce06e
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.871 s

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira: #733 #719
- [x] Link to relevant pull requests, esp. upstream and downstream changes: 
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
