### PR TITLE
Handle noisy docker run output when parsing container IDs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
@@ -71,6 +71,8 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 public class DockerClient {
 
     private static final Logger LOGGER = Logger.getLogger(DockerClient.class.getName());
+    private static final Pattern CONTAINER_ID_LINE_PATTERN = Pattern.compile("^([0-9a-f]{12,64})$");
+    private static final Pattern CONTAINER_ID_TOKEN_PATTERN = Pattern.compile("\\b([0-9a-f]{12,64})\\b");
 
     /**
      * Maximum amount of time (in seconds) to wait for {@code docker} client operations which are supposed to be more or less instantaneous.
@@ -143,16 +145,17 @@ public class DockerClient {
 
         LaunchResult result = launch(launchEnv, false, null, argb);
         if (result.getStatus() == 0) {
-            return result.getOut();
+            return normalizeContainerIdOutput(result.getOut());
         } else {
             throw new IOException(String.format("Failed to run image '%s'. Error: %s", image, result.getErr()));
         }
     }
 
     public List<String> listProcess(@NonNull EnvVars launchEnv, @NonNull String containerId) throws IOException, InterruptedException {
-        LaunchResult result = launch(launchEnv, false, "top", containerId, "-eo", "pid,comm");
+        String normalizedContainerId = normalizeContainerIdOutput(containerId);
+        LaunchResult result = launch(launchEnv, false, "top", normalizedContainerId, "-eo", "pid,comm");
         if (result.getStatus() != 0) {
-            throw new IOException(String.format("Failed to run top '%s'. Error: %s", containerId, result.getErr()));
+            throw new IOException(String.format("Failed to run top '%s'. Error: %s", normalizedContainerId, result.getErr()));
         }
         List<String> processes = new ArrayList<>();
         try (Reader r = new StringReader(result.getOut());
@@ -169,6 +172,31 @@ public class DockerClient {
             }
         }
         return processes;
+    }
+
+    static @NonNull String normalizeContainerIdOutput(@CheckForNull String output) throws IOException {
+        if (output == null) {
+            throw new IOException("Container ID is missing from docker output");
+        }
+        try (Reader stringReader = new StringReader(output);
+             BufferedReader reader = new BufferedReader(stringReader)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String trimmed = line.trim();
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
+                Matcher exactLineMatcher = CONTAINER_ID_LINE_PATTERN.matcher(trimmed);
+                if (exactLineMatcher.matches()) {
+                    return exactLineMatcher.group(1);
+                }
+                Matcher tokenMatcher = CONTAINER_ID_TOKEN_PATTERN.matcher(trimmed);
+                if (tokenMatcher.find()) {
+                    return tokenMatcher.group(1);
+                }
+            }
+        }
+        throw new IOException(String.format("Unable to parse container ID from docker output: %s", output));
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientContainerIdParserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/client/DockerClientContainerIdParserTest.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.workflow.client;
+
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DockerClientContainerIdParserTest {
+
+    @Test
+    public void parsesSingleLineContainerId() throws Exception {
+        String output = "ee632b4c84ed5aaea15608d5180169dfc7eedeaf7021a6724232e61c1f4d5d4c\n";
+        Assert.assertEquals(
+            "ee632b4c84ed5aaea15608d5180169dfc7eedeaf7021a6724232e61c1f4d5d4c",
+            DockerClient.normalizeContainerIdOutput(output));
+    }
+
+    @Test
+    public void parsesContainerIdWhenWarningIsAppendedOnFollowingLine() throws Exception {
+        String output =
+            "ee632b4c84ed5aaea15608d5180169dfc7eedeaf7021a6724232e61c1f4d5d4c\n"
+                + "Process leaked file descriptors. See https://www.jenkins.io/redirect/troubleshooting/process-leaked-file-descriptors for more information\n";
+        Assert.assertEquals(
+            "ee632b4c84ed5aaea15608d5180169dfc7eedeaf7021a6724232e61c1f4d5d4c",
+            DockerClient.normalizeContainerIdOutput(output));
+    }
+
+    @Test
+    public void rejectsOutputWithoutContainerId() {
+        IOException thrown = Assert.assertThrows(
+            IOException.class,
+            () -> DockerClient.normalizeContainerIdOutput("Process leaked file descriptors\n"));
+        Assert.assertTrue(thrown.getMessage().contains("Unable to parse container ID"));
+    }
+}


### PR DESCRIPTION
Parse and normalize container IDs from docker command output so Jenkins leaked-file-descriptor warnings do not corrupt docker top arguments, and add regression tests for noisy output cases.

Attempt to fix Process Leaked Descriptors as described [here](https://github.com/jenkinsci/docker-workflow-plugin/issues/657)

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
