### PR TITLE
[JENKINS-73447] Do not fail the build when `docker top` is unavailable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java
@@ -198,8 +198,17 @@ public class WithContainerStep extends AbstractStepImpl {
 
             String command = launcher.isUnix() ? "cat" : "cmd.exe";
             container = dockerClient.run(env, step.image, step.args, ws, volumes, volumesFromContainers, envReduced, dockerClient.whoAmI(), /* expected to hang until killed */ command);
-            final List<String> ps = dockerClient.listProcess(env, container);
-            if (!ps.contains(command)) {
+            // The process list is only a diagnostic: `docker top` needs cgroups, and fails on configurations such as
+            // rootless Docker or rootless dind where the container itself is perfectly healthy (JENKINS-73447).
+            // Skip the check rather than failing the build when the process list cannot be obtained.
+            List<String> ps = null;
+            try {
+                ps = dockerClient.listProcess(env, container);
+            } catch (IOException x) {
+                LOGGER.log(Level.FINE, "failed to list processes in container " + container, x);
+                listener.getLogger().println("Could not verify the command running in the container: " + x.getMessage());
+            }
+            if (ps != null && !ps.contains(command)) {
                 listener.error(
                     "The container started but didn't run the expected command. " +
                         "Please double check your ENTRYPOINT does execute the command passed as docker run argument, " +

--- a/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/workflow/WithContainerStepTest.java
@@ -37,7 +37,9 @@ import hudson.tools.ToolProperty;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.Secret;
 import hudson.util.StreamTaskListener;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.logging.Level;
@@ -69,6 +71,7 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.Assume;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -118,6 +121,49 @@ public class WithContainerStepTest {
                     "}", true));
                 WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
                 story.j.assertLogContains("Require method GET POST OPTIONS", b);
+            }
+        });
+    }
+
+    @Issue("JENKINS-73447")
+    @Test public void topFailureIsNotFatal() {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                DockerTestUtil.assumeDocker();
+                DockerTestUtil.assumeNotWindows();
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                Launcher.LocalLauncher localLauncher = new Launcher.LocalLauncher(StreamTaskListener.NULL);
+                localLauncher.launch().cmds("/bin/sh", "-c", "command -v docker").stdout(out).start().
+                        joinWithTimeout(DockerClient.CLIENT_TIMEOUT, TimeUnit.SECONDS, localLauncher.getListener());
+                String realDocker = out.toString(StandardCharsets.UTF_8).trim();
+                assumeTrue("found docker on $PATH", !realDocker.isEmpty());
+                // Stand in for a daemon where `docker top` fails because cgroups are unavailable, as with rootless Docker.
+                File toolHome = tmp.newFolder("no-cgroups");
+                File bin = new File(toolHome, "bin");
+                assertTrue(bin.mkdirs());
+                File fakeDocker = new File(bin, "docker");
+                FileUtils.writeStringToFile(fakeDocker,
+                    "#!/bin/sh\n" +
+                    "if [ \"$1\" = top ]; then\n" +
+                    "  echo 'Error response from daemon: runc did not terminate successfully: unable to get all container pids: operation not supported' >&2\n" +
+                    "  exit 1\n" +
+                    "fi\n" +
+                    "exec " + realDocker + " \"$@\"\n", StandardCharsets.UTF_8);
+                assertTrue(fakeDocker.setExecutable(true));
+                story.j.jenkins.getDescriptorByType(DockerTool.DescriptorImpl.class).setInstallations(
+                        new DockerTool("no-cgroups", toolHome.getAbsolutePath(), Collections.<ToolProperty<?>>emptyList()));
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "prj");
+                p.setDefinition(new CpsFlowDefinition(
+                    "node {\n" +
+                    "  withDockerContainer(image: 'httpd:2.4.59', toolName: 'no-cgroups') {\n" +
+                    "    sh 'echo hello from the container'\n" +
+                    "  }\n" +
+                    "}", true));
+                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                story.j.assertLogContains("Could not verify the command running in the container", b);
+                story.j.assertLogContains("hello from the container", b);
+                // The process list was unavailable, so the entrypoint diagnostic must not be reported as a failure.
+                story.j.assertLogNotContains("didn't run the expected command", b);
             }
         });
     }


### PR DESCRIPTION
Fixes #716 / [JENKINS-73447](https://issues.jenkins.io/browse/JENKINS-73447).

### Problem

After starting the container, `WithContainerStep` calls `docker top` to check that the
container is actually running the expected command (`cat` / `cmd.exe`) rather than
something from an `ENTRYPOINT`. `docker top` requires cgroups, so on rootless Docker and
rootless dind it fails outright:

Error response from daemon: runc did not terminate successfully: exit status 1:
unable to get all container pids: read /sys/fs/cgroup/<id>/cgroup.procs: operation not supported

The check is only ever advisory — when the process list does not contain the expected
command the step just logs an error and carries on — but an `IOException` from
`listProcess` propagated out of `Execution.start()` and failed the build, even though the
container was healthy.

### Fix

Catch the `IOException`, log it at `FINE`, print a short note to the build log, and skip
the check. `InterruptedException` is deliberately not caught, so aborts still work.
`listProcess` is left throwing rather than returning an empty list, since an empty list
would trip the `!ps.contains(command)` branch and print the misleading "container started
but didn't run the expected command" message.

### Testing

Added `WithContainerStepTest.topFailureIsNotFatal`, which installs a `DockerTool` whose
`bin/docker` is a wrapper that fails on `top` with the daemon error above and delegates
every other subcommand to the real `docker` — a stand-in for a cgroup-less daemon that
needs no refactoring of the step to inject a mock.

- Without the fix the test fails with `java.io.IOException: Failed to run top '<id>'` and
  `Finished: FAILURE`, reproducing the reported bug.
- With the fix the build succeeds, the body runs, and the log shows
  `Could not verify the command running in the container: ...`.

`mvn verify -Dtest=WithContainerStepTest` passes locally against a real Linux daemon
(15 tests, 0 failures, SpotBugs clean). The new test calls `assumeNotWindows()`, since the
wrapper is a `/bin/sh` script, so it skips on the Windows CI leg.

### Note

The reporter also suggested a system property to disable the process-list check outright.
I left that out — making the check non-fatal resolves the reported failure without adding
configuration surface — but I'm happy to add one if you'd prefer it.
